### PR TITLE
[FE] React Context 기반 전역 로그인 상태 관리

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,59 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <HTMLCodeStyleSettings>
+      <option name="HTML_SPACE_INSIDE_EMPTY_TAG" value="true" />
+    </HTMLCodeStyleSettings>
+    <JSCodeStyleSettings version="0">
+      <option name="FORCE_SEMICOLON_STYLE" value="true" />
+      <option name="SPACE_BEFORE_FUNCTION_LEFT_PARENTH" value="false" />
+      <option name="USE_DOUBLE_QUOTES" value="false" />
+      <option name="FORCE_QUOTE_STYlE" value="true" />
+      <option name="ENFORCE_TRAILING_COMMA" value="Remove" />
+      <option name="SPACES_WITHIN_OBJECT_LITERAL_BRACES" value="true" />
+      <option name="SPACES_WITHIN_IMPORTS" value="true" />
+    </JSCodeStyleSettings>
+    <TypeScriptCodeStyleSettings version="0">
+      <option name="FORCE_SEMICOLON_STYLE" value="true" />
+      <option name="SPACE_BEFORE_FUNCTION_LEFT_PARENTH" value="false" />
+      <option name="USE_DOUBLE_QUOTES" value="false" />
+      <option name="FORCE_QUOTE_STYlE" value="true" />
+      <option name="ENFORCE_TRAILING_COMMA" value="Remove" />
+      <option name="SPACES_WITHIN_OBJECT_LITERAL_BRACES" value="true" />
+      <option name="SPACES_WITHIN_IMPORTS" value="true" />
+    </TypeScriptCodeStyleSettings>
+    <VueCodeStyleSettings>
+      <option name="INTERPOLATION_NEW_LINE_AFTER_START_DELIMITER" value="false" />
+      <option name="INTERPOLATION_NEW_LINE_BEFORE_END_DELIMITER" value="false" />
+    </VueCodeStyleSettings>
+    <codeStyleSettings language="HTML">
+      <option name="SOFT_MARGINS" value="80" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="JavaScript">
+      <option name="SOFT_MARGINS" value="80" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="TypeScript">
+      <option name="SOFT_MARGINS" value="80" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="Vue">
+      <option name="SOFT_MARGINS" value="80" />
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -9,22 +9,31 @@
       "error",
       { "singleQuote": true, "endOfLine": "auto" }
     ],
-    "react/react-in-jsx-scope": "off", // React 17 이상에서는 이 규칙을 꺼야 합니다
-    "react/jsx-uses-react": "off", // React 자동 변환 설정으로 인해 필요 없음
-    "react/jsx-uses-vars": "error" // JSX 내에서 사용된 변수를 인식하게 설정
+    "react/react-in-jsx-scope": "off",
+    "react/jsx-uses-react": "off",
+    "react/jsx-uses-vars": "error"
   },
-  "parser": "@babel/eslint-parser",
+  "parser": "@typescript-eslint/parser",
   "parserOptions": {
-    "requireConfigFile": false,
-    "babelOptions": {
-      "presets": ["@babel/preset-react", "@babel/preset-typescript"]
+    "ecmaVersion": 2020,
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "jsx": true
     }
   },
-  "plugins": ["@typescript-eslint"],
-  "ignorePatterns": ["*.html"], // HTML 파일 무시
+  "plugins": ["@typescript-eslint", "react"],
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  },
+  "ignorePatterns": ["*.html"],
   "overrides": [
     {
-      "files": ["*.js", "*.jsx", "*.ts", "*.tsx"]
+      "files": ["*.ts", "*.tsx"],
+      "parserOptions": {
+        "project": "./tsconfig.json"
+      }
     }
   ]
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import Index from './pages/Index/Index';
 import Footer from './components/Footer/Footer';
 import SignIn from './pages/Auth/SignIn';
+import { AuthProvider } from './context/AuthContext';
 
 const PageContainer = styled.div`
   display: flex;
@@ -14,16 +15,18 @@ const PageContainer = styled.div`
 function App() {
   return (
     <Router>
-      <PageContainer>
-        <Header />
-        <Routes>
-          {' '}
-          {/* Route는 반드시 Routes로 감싸야 합니다 */}
-          <Route path="/" element={<Index />} />
-          <Route path="/signin" element={<SignIn />} />
-        </Routes>
-        <Footer />
-      </PageContainer>
+      <AuthProvider>
+        <PageContainer>
+          <Header />
+          <Routes>
+            {' '}
+            {/* Route는 반드시 Routes로 감싸야 합니다 */}
+            <Route path="/" element={<Index />} />
+            <Route path="/signin" element={<SignIn />} />
+          </Routes>
+          <Footer />
+        </PageContainer>
+      </AuthProvider>
     </Router>
   );
 }

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -6,8 +6,8 @@ import axios from 'axios';
 interface AuthContextType {
   user: string | null;
   isAuthenticated: boolean;
-  login: (userEmail: string, password: string) => Promise<void>;
-  logout: () => void;
+  signin: (userEmail: string, password: string) => Promise<void>;
+  signout: () => void;
 }
 
 interface Props {
@@ -21,48 +21,30 @@ export const AuthProvider: React.FC<Props> = ({ children }) => {
   const [user, setUser] = useState<string | null>(null); // 사용자 정보를 저장
   const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false); // 인증 상태
 
-  // 로그인 요청 함수
-  async function loginRequest(
-    userEmail: string,
-    password: string,
-  ): Promise<string> {
+  // 로그인 함수: 사용자가 로그인할 때 호출
+  const signin = async (userEmail: string, password: string) => {
     try {
       const response = await axios.post('/api/login', {
         email: userEmail,
-        password: password,
+        password,
       });
 
-      if (response.status === 200) {
-        return response.data.token; // 서버로부터 받은 JWT 토큰
-      } else {
-        throw new Error('로그인 실패: 서버 오류');
-      }
+      // 서버에서 토큰을 받아온다
+      const token = response.data.token;
+
+      // 로그인 성공 시 사용자 정보 업데이트
+      setUser(userEmail);
+      setIsAuthenticated(true);
+
+      // 받은 JWT 토큰을 로컬 스토리지 등에 저장
+      localStorage.setItem('token', token);
     } catch (error) {
-      if (axios.isAxiosError(error)) {
-        console.error('로그인 실패: 서버 오류', error.response?.data);
-        throw new Error('서버 오류로 인해 로그인 실패');
-      } else {
-        console.error('로그인 실패: 네트워크 오류 또는 기타 문제', error);
-        throw new Error('네트워크 오류로 인해 로그인 실패');
-      }
+      console.error('로그인 실패:', error);
     }
-  }
-
-  // 로그인 함수: 사용자가 로그인할 때 호출
-  const login = async (userEmail: string, password: string) => {
-    // 서버에 로그인 요청을 보내고 JWT 토큰을 받아오는 로직
-    const token = await loginRequest(userEmail, password);
-
-    // 로그인 성공 시 사용자 정보 업데이트
-    setUser(userEmail);
-    setIsAuthenticated(true);
-
-    // 받은 JWT 토큰을 로컬 스토리지 등에 저장하여 사용
-    localStorage.setItem('token', token);
   };
 
   // 로그아웃 함수: 사용자가 로그아웃할 때 호출
-  const logout = () => {
+  const signout = () => {
     setUser(null);
     setIsAuthenticated(false);
     localStorage.removeItem('token'); // 토큰 삭제
@@ -72,8 +54,8 @@ export const AuthProvider: React.FC<Props> = ({ children }) => {
   const authValue: AuthContextType = {
     user, // 현재 사용자 정보
     isAuthenticated, // 로그인 상태
-    login, // 로그인 함수
-    logout, // 로그아웃 함수
+    signin, // 로그인 함수
+    signout, // 로그아웃 함수
   };
 
   // children 컴포넌트에게 value 값을 제공

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,8 +1,6 @@
 import { createContext, useState, ReactNode } from 'react';
-import React from 'react';
 import axios from 'axios';
 
-// 로그인 상태와 함수를 담는 타입 정의
 interface AuthContextType {
   user: string | null;
   isAuthenticated: boolean;
@@ -10,23 +8,22 @@ interface AuthContextType {
   signout: () => void;
 }
 
-interface Props {
-  children: React.ReactNode;
-}
-
 // 초기값 정의
-const AuthContext = React.createContext<AuthContextType | undefined>(undefined);
+export const AuthContext = createContext<AuthContextType | undefined>(
+  undefined,
+);
 
-export const AuthProvider: React.FC<Props> = ({ children }) => {
-  const [user, setUser] = useState<string | null>(null); // 사용자 정보를 저장
-  const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false); // 인증 상태
+export const AuthProvider: React.FC<{ children: ReactNode }> = ({
+  children,
+}) => {
+  const [user, setUser] = useState<string | null>(null);
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false);
 
-  // 로그인 함수: 사용자가 로그인할 때 호출
   const signin = async (userEmail: string, password: string) => {
     try {
       const response = await axios.post('/api/login', {
         email: userEmail,
-        password,
+        password: password,
       });
 
       // 서버에서 토큰을 받아온다
@@ -40,25 +37,24 @@ export const AuthProvider: React.FC<Props> = ({ children }) => {
       localStorage.setItem('token', token);
     } catch (error) {
       console.error('로그인 실패:', error);
+      // 오류가 발생하면 예외를 던져서 상위에서 처리할 수 있도록 함
+      throw error;
     }
   };
 
-  // 로그아웃 함수: 사용자가 로그아웃할 때 호출
   const signout = () => {
     setUser(null);
     setIsAuthenticated(false);
-    localStorage.removeItem('token'); // 토큰 삭제
+    localStorage.removeItem('token');
   };
 
-  // AuthContext.Provider가 제공하는 value 객체
   const authValue: AuthContextType = {
-    user, // 현재 사용자 정보
-    isAuthenticated, // 로그인 상태
-    signin, // 로그인 함수
-    signout, // 로그아웃 함수
+    user,
+    isAuthenticated,
+    signin,
+    signout,
   };
 
-  // children 컴포넌트에게 value 값을 제공
   return (
     <AuthContext.Provider value={authValue}>{children}</AuthContext.Provider>
   );

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,0 +1,83 @@
+import { createContext, useState, ReactNode } from 'react';
+import React from 'react';
+import axios from 'axios';
+
+// 로그인 상태와 함수를 담는 타입 정의
+interface AuthContextType {
+  user: string | null;
+  isAuthenticated: boolean;
+  login: (userEmail: string, password: string) => Promise<void>;
+  logout: () => void;
+}
+
+interface Props {
+  children: React.ReactNode;
+}
+
+// 초기값 정의
+const AuthContext = React.createContext<AuthContextType | undefined>(undefined);
+
+export const AuthProvider: React.FC<Props> = ({ children }) => {
+  const [user, setUser] = useState<string | null>(null); // 사용자 정보를 저장
+  const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false); // 인증 상태
+
+  // 로그인 요청 함수
+  async function loginRequest(
+    userEmail: string,
+    password: string,
+  ): Promise<string> {
+    try {
+      const response = await axios.post('/api/login', {
+        email: userEmail,
+        password: password,
+      });
+
+      if (response.status === 200) {
+        return response.data.token; // 서버로부터 받은 JWT 토큰
+      } else {
+        throw new Error('로그인 실패: 서버 오류');
+      }
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        console.error('로그인 실패: 서버 오류', error.response?.data);
+        throw new Error('서버 오류로 인해 로그인 실패');
+      } else {
+        console.error('로그인 실패: 네트워크 오류 또는 기타 문제', error);
+        throw new Error('네트워크 오류로 인해 로그인 실패');
+      }
+    }
+  }
+
+  // 로그인 함수: 사용자가 로그인할 때 호출
+  const login = async (userEmail: string, password: string) => {
+    // 서버에 로그인 요청을 보내고 JWT 토큰을 받아오는 로직
+    const token = await loginRequest(userEmail, password);
+
+    // 로그인 성공 시 사용자 정보 업데이트
+    setUser(userEmail);
+    setIsAuthenticated(true);
+
+    // 받은 JWT 토큰을 로컬 스토리지 등에 저장하여 사용
+    localStorage.setItem('token', token);
+  };
+
+  // 로그아웃 함수: 사용자가 로그아웃할 때 호출
+  const logout = () => {
+    setUser(null);
+    setIsAuthenticated(false);
+    localStorage.removeItem('token'); // 토큰 삭제
+  };
+
+  // AuthContext.Provider가 제공하는 value 객체
+  const authValue: AuthContextType = {
+    user, // 현재 사용자 정보
+    isAuthenticated, // 로그인 상태
+    login, // 로그인 함수
+    logout, // 로그아웃 함수
+  };
+
+  // children 컴포넌트에게 value 값을 제공
+  return (
+    <AuthContext.Provider value={authValue}>{children}</AuthContext.Provider>
+  );
+};


### PR DESCRIPTION
- [ ] 💯 테스트는 잘 통과했나요?
- [0] 🏗️ 빌드는 성공했나요?
- [0] 🧹 불필요한 코드는 제거했나요?
- [0] 💭 이슈는 등록했나요?
- [0] 🏷️ 라벨은 등록했나요?

#36 작업 내용

## 🤷 구현할 기능

로그인 반환값인 JWT기반 전역 상태 관리 구현

## 🔨 상세 작업 내용

- Context 정의 및 전역 상태 관리
- AuthContext
- JWT 토큰 기반
- 토큰을 로컬 저장소에 저장하여 새로고침시에도 로그아웃 방지

주요 함수:
• signin(userEmail, password): 서버에 로그인 요청 후 사용자 정보 및 토큰 설정
• signout(): 사용자 정보 및 인증 상태 초기화, 토큰 삭제

## 노션 링크

### JWT토큰
https://www.notion.so/JWT-52592b5752aa45be8b7999d9fb3faa01?pvs=4
### React Context
https://velog.io/@jiyaho/React-Context-API%EC%9D%98-%EA%B0%9C%EB%85%90-%EB%B0%8F-%EC%82%AC%EC%9A%A9%EB%B2%95

- [ o] To-do 1 - Swagger 명세 기반 - api uri 및 에러 처리는 임시로 진행
- [ o] To-do 2 - 새로고침시에도 로그인 상태 유지 - 로컬 저장 로직
- [ o] To-do 3 - 로그인 컴포넌트에 적용 

## 📄 참고 사항
React Context API 사용

## 사용 방법

### import

AuthContext 임포트

다른 컴포넌트에서 `AuthProvider`가 제공하는 값에 접근하려면, `AuthContext`를 임포트합니다.

```tsx
import { useContext } from 'react';
import { AuthContext } from '../context/AuthContext';
```

### AuthContext 값 가져오기

useContext를 사용하여 AuthContext에 접근합니다.

```tsx
const { user, isAuthenticated, signout } = useContext(AuthContext);
```

## ⏰ 예상 소요 기간
3일

## 스크린샷
<img width="561" alt="image" src="https://github.com/user-attachments/assets/fc1940aa-4af7-44bc-91a1-2693b905a8e5">

## 주의사항
추후 로그인 테스트 시 임시 uri 변경
이후 로그인 실패 예외처리 추가 ( 비밀번호, 아이디 틀림 등등)

Closes #36