### PR TITLE
#60 refactor: uri 주소 변경 및 로그인 json 값 수정

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,1 +1,1 @@
-REACT_APP_API_URL=http://localhost:3000
+REACT_APP_API_URL=http://localhost:8080

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -24,18 +24,27 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   const signin = async (userName: string, password: string) => {
     try {
-      const response = await axios.post(`${apiUrl}/api/admin/join`, {
+      console.log(
+        `try to sign in as username: :${userName} password: ${password}`,
+      );
+      const response = await axios.post(`${apiUrl}/api/admin/login`, {
         username: userName,
         password: password,
       });
 
       // 서버에서 토큰을 받아온다
-      const token = response.data.token;
+      const authorizationHeader = response.headers['authorization']; // 헤더에서 'authorization' 추출
+      const token = authorizationHeader && authorizationHeader.split(' ')[1]; // 'Bearer' 제거 후 JWT 토큰만 추출
+
+      // if (!token) {
+      //   throw new Error('JWT 토큰을 찾을 수 없습니다.');
+      // }
 
       // 로그인 성공 시 사용자 정보 업데이트
       setUser(userName);
       setIsAuthenticated(true);
 
+      console.log('저장할 JWT토큰:', token);
       // 받은 JWT 토큰을 로컬 스토리지 등에 저장
       localStorage.setItem('token', token);
     } catch (error) {

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -28,7 +28,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         `try to sign in as username: :${userName} password: ${password}`,
       );
       const response = await axios.post(`${apiUrl}/api/admin/login`, {
-        username: userName,
+        userId: userName,
         password: password,
       });
 

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -4,7 +4,7 @@ import axios from 'axios';
 interface AuthContextType {
   user: string | null;
   isAuthenticated: boolean;
-  signin: (userId: string, password: string) => Promise<void>;
+  signin: (userName: string, password: string) => Promise<void>;
   signout: () => void;
 }
 
@@ -20,11 +20,12 @@ interface AuthProviderProps {
 export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const [user, setUser] = useState<string | null>(null);
   const [isAuthenticated, setIsAuthenticated] = useState<boolean>(false);
+  const apiUrl = process.env.REACT_APP_API_URL || 'http://localhost:8080';
 
-  const signin = async (userId: string, password: string) => {
+  const signin = async (userName: string, password: string) => {
     try {
-      const response = await axios.post('/api/login', {
-        email: userId,
+      const response = await axios.post(`${apiUrl}/api/admin/join`, {
+        username: userName,
         password: password,
       });
 
@@ -32,7 +33,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       const token = response.data.token;
 
       // 로그인 성공 시 사용자 정보 업데이트
-      setUser(userId);
+      setUser(userName);
       setIsAuthenticated(true);
 
       // 받은 JWT 토큰을 로컬 스토리지 등에 저장

--- a/frontend/src/pages/Auth/SignIn.tsx
+++ b/frontend/src/pages/Auth/SignIn.tsx
@@ -22,15 +22,16 @@ const SignIn: React.FC = () => {
   }
 
   const { signin, isAuthenticated } = authContext; // 정확한 signin 및 isAuthenticated 사용
-  const [id, setId] = useState('');
+
+  const [userName, setUserName] = useState('');
   const [password, setPassword] = useState('');
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const loginData = { id: id, pw: password };
-
     try {
-      await signin(loginData.id, loginData.pw);
+      console.log('try to login');
+
+      await signin(userName, password);
       openModal(
         <div>
           <h2>로그인 성공</h2>
@@ -62,13 +63,13 @@ const SignIn: React.FC = () => {
         <Title>관리자 로그인</Title>
         <Input
           type="text"
-          placeholder="Email"
-          value={id}
-          onChange={(e) => setId(e.target.value)}
+          placeholder="ID"
+          value={userName}
+          onChange={(e) => setUserName(e.target.value)}
         />
         <Input
           type="password"
-          placeholder="Password"
+          placeholder="PW"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
         />


### PR DESCRIPTION
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?

## 작업 내용

## 🤷 리펙토링할 기능

FE에서 서로 맞지않는 로그인 요청 JSON 값 변경 및 로그인 테스트

## 📄 참고 사항

URI 및 요청 JSON 값 변경

JWT 토큰 테스트 진행

# 테스트 결과

## 200 응답 성공
![image](https://github.com/user-attachments/assets/fefa36f5-204f-4678-829c-6e44cc4ca9d2)

## JWT 토큰 - 실패
![image](https://github.com/user-attachments/assets/7ecf3b6f-de6f-41eb-868c-ecf6c9bcb559)

![image](https://github.com/user-attachments/assets/d4a5f440-5114-49ae-a292-8ca9e3fd1884)

- 1. 로그인 페이지에서 사용자 이름과 비밀번호 입력 후 로그인 요청 전송
- 2. 서버로부터 성공적인 응답 (`200 OK`)을 받았으나, JWT 토큰이 응답에 포함되지 않음
- 3. 클라이언트 브라우저 `localStorage`에 저장된 값은 `undefined`

### 기대 결과 및 실제 결과

서버가 성공적으로 로그인하면, JWT 토큰을 포함한 응답이 반환되어야 합니다.
응답 데이터는 다음과 같은 형식
```json
  "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
```

## 기능 요청 사항
- 로그인 아이디 및 비밀번호가 인증 실패 시 응답 상태 코드 추가
HTTP 상태 코드:
401 Unauthorized: 인증 실패 시 주로 사용되는 상태 코드입니다.
응답 메시지:
응답 본문에는 실패 이유(아이디 또는 비밀번호가 틀린 경우 등)가 JSON 형식으로 포함
```json
  "error": "Invalid username or password"
```

Closes #60 