### PR TITLE
도커 문제 해결

### DIFF
--- a/backend/backup.sql
+++ b/backend/backup.sql
@@ -196,3 +196,54 @@ UNLOCK TABLES;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
 -- Dump completed on 2024-10-11 16:04:22
+
+-- Seminar 테이블 생성
+CREATE TABLE IF NOT EXISTS `seminar` (
+  `seminar_id` bigint NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) DEFAULT NULL,
+  `writer` varchar(255) DEFAULT NULL,
+  `place` varchar(255) DEFAULT NULL,
+  `start_date` date DEFAULT NULL,
+  `end_date` date DEFAULT NULL,
+  `speaker` varchar(255) DEFAULT NULL,
+  `company` varchar(255) DEFAULT NULL,
+  `department_id` bigint DEFAULT NULL,
+  PRIMARY KEY (`seminar_id`),
+  KEY `FK_seminar_department` (`department_id`),
+  CONSTRAINT `FK_seminar_department` FOREIGN KEY (`department_id`) REFERENCES `Department` (`department_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Thesis 테이블 생성
+CREATE TABLE IF NOT EXISTS `thesis` (
+  `thesis_id` bigint NOT NULL AUTO_INCREMENT,
+  `author` varchar(255) DEFAULT NULL,
+  `journal` varchar(255) DEFAULT NULL,
+  `content` text,
+  `link` varchar(255) DEFAULT NULL,
+  `publication_date` date DEFAULT NULL,
+  `thesis_image` varchar(255) DEFAULT NULL,
+  `publication_collection` varchar(255) DEFAULT NULL,
+  `publication_issue` varchar(255) DEFAULT NULL,
+  `publication_page` varchar(255) DEFAULT NULL,
+  `issn` varchar(20) DEFAULT NULL,
+  `professor_id` bigint DEFAULT NULL,
+  PRIMARY KEY (`thesis_id`),
+  KEY `FK_thesis_professor` (`professor_id`),
+  CONSTRAINT `FK_thesis_professor` FOREIGN KEY (`professor_id`) REFERENCES `professor` (`professor_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Board 테이블 생성
+CREATE TABLE IF NOT EXISTS `board` (
+  `board_id` bigint NOT NULL AUTO_INCREMENT,
+  `title` varchar(255) DEFAULT NULL,
+  `content` text,
+  `view_count` int DEFAULT '0',
+  `writer` varchar(255) DEFAULT NULL,
+  `file` varchar(255) DEFAULT NULL,
+  `create_date` datetime DEFAULT CURRENT_TIMESTAMP,
+  `category` varchar(50) DEFAULT NULL,
+  `department_id` bigint DEFAULT NULL,
+  PRIMARY KEY (`board_id`),
+  KEY `FK_board_department` (`department_id`),
+  CONSTRAINT `FK_board_department` FOREIGN KEY (`department_id`) REFERENCES `Department` (`department_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/backend/docker-compose-dev.yml
+++ b/backend/docker-compose-dev.yml
@@ -10,19 +10,21 @@ services:
       - "3307:3306"
     volumes:
       - db-data:/var/lib/mysql
-      - ./backup.sql:/docker-entrypoint-initdb.d/1-backup.sql
+      - ./src/main/resources/schema.sql:/docker-entrypoint-initdb.d/1-schema.sql
       - ./src/main/resources/data.sql:/docker-entrypoint-initdb.d/2-data.sql
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -u root -p$$MYSQL_ROOT_PASSWORD"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 10s
     command:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
-      - --lower_case_table_names=1  # 테이블명 대소문자 구분 비활성화
-    healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-pdibb2024"]
-      interval: 5s
-      timeout: 5s
-      retries: 10
+      - --skip-character-set-client-handshake
+      - --default-authentication-plugin=mysql_native_password
     networks:
-      - dev-network
+      - dibb-network
 
   backend:
     container_name: dibb-backend-container-dev
@@ -31,21 +33,22 @@ services:
       - "8082:8080"
     environment:
       SPRING_PROFILES_ACTIVE: docker-dev
-      SPRING_DATASOURCE_URL: jdbc:mysql://db:3306/dibb?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=UTF-8
+      SPRING_DATASOURCE_URL: jdbc:mysql://db:3306/dibb?allowPublicKeyRetrieval=true&useSSL=false&serverTimezone=UTC
       SPRING_DATASOURCE_USERNAME: root
       SPRING_DATASOURCE_PASSWORD: dibb2024
-      SPRING_JPA_HIBERNATE_DDL_AUTO: none
       SPRING_JPA_DATABASE_PLATFORM: org.hibernate.dialect.MySQLDialect
+      SPRING_JPA_HIBERNATE_DDL_AUTO: none
+      SPRING_JPA_SHOW_SQL: "true"
+      SPRING_JPA_DEFER_DATASOURCE_INITIALIZATION: "true"
+      SPRING_SQL_INIT_MODE: always
     depends_on:
       db:
         condition: service_healthy
-    volumes:
-      - ./src:/app/src
     networks:
-      - dev-network
+      - dibb-network
 
 networks:
-  dev-network:
+  dibb-network:
     driver: bridge
 
 volumes:

--- a/backend/docker-compose-dev.yml
+++ b/backend/docker-compose-dev.yml
@@ -6,17 +6,16 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: dibb2024
       MYSQL_DATABASE: dibb
-      MYSQL_CHARSET: utf8mb4
-      MYSQL_COLLATION: utf8mb4_unicode_ci
     ports:
       - "3307:3306"
     volumes:
       - db-data:/var/lib/mysql
-      - ./backup.sql:/docker-entrypoint-initdb.d/1-backup.sql  # 테이블 생성 SQL
-      - ./src/main/resources/data.sql:/docker-entrypoint-initdb.d/2-data.sql  # 데이터 삽입 SQL
+      - ./backup.sql:/docker-entrypoint-initdb.d/1-backup.sql
+      - ./src/main/resources/data.sql:/docker-entrypoint-initdb.d/2-data.sql
     command:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
+      - --lower_case_table_names=1  # 테이블명 대소문자 구분 비활성화
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-pdibb2024"]
       interval: 5s

--- a/backend/docker-compose-dev.yml
+++ b/backend/docker-compose-dev.yml
@@ -13,6 +13,12 @@ services:
       - ./backup.sql:/docker-entrypoint-initdb.d/backup.sql
     networks:
       - dev-network
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-pdibb2024"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
 
   backend:
     container_name: dibb-backend-container-dev
@@ -20,17 +26,23 @@ services:
     ports:
       - "8082:8080"
     environment:
-      SPRING_PROFILES_ACTIVE: docker-dev  # dev 환경 설정을 사용
-      SPRING_DATASOURCE_URL: jdbc:mysql://dibb-db-dev:3306/dibb?useSSL=false&allowPublicKeyRetrieval=true
+      SPRING_PROFILES_ACTIVE: docker-dev
+      SPRING_DATASOURCE_URL: jdbc:mysql://dibb-db-dev:3306/dibb?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=UTF-8
       SPRING_DATASOURCE_USERNAME: root
       SPRING_DATASOURCE_PASSWORD: dibb2024
       SPRING_JPA_HIBERNATE_DDL_AUTO: update
+      SPRING_JPA_PROPERTIES_HIBERNATE_DIALECT: org.hibernate.dialect.MySQLDialect
+      SPRING_JPA_SHOW_SQL: "true"
+      SPRING_JPA_PROPERTIES_HIBERNATE_FORMAT_SQL: "true"
+      SPRING_JPA_DEFER_DATASOURCE_INITIALIZATION: "true"
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     volumes:
       - ./src:/app/src
     networks:
       - dev-network
+    restart: unless-stopped
 
 networks:
   dev-network:

--- a/backend/docker-compose-dev.yml
+++ b/backend/docker-compose-dev.yml
@@ -6,19 +6,24 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: dibb2024
       MYSQL_DATABASE: dibb
+      MYSQL_CHARSET: utf8mb4
+      MYSQL_COLLATION: utf8mb4_unicode_ci
     ports:
       - "3307:3306"
     volumes:
       - db-data:/var/lib/mysql
-      - ./backup.sql:/docker-entrypoint-initdb.d/backup.sql
-    networks:
-      - dev-network
+      - ./backup.sql:/docker-entrypoint-initdb.d/1-backup.sql  # 테이블 생성 SQL
+      - ./src/main/resources/data.sql:/docker-entrypoint-initdb.d/2-data.sql  # 데이터 삽입 SQL
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-pdibb2024"]
-      interval: 10s
+      interval: 5s
       timeout: 5s
-      retries: 5
-      start_period: 30s
+      retries: 10
+    networks:
+      - dev-network
 
   backend:
     container_name: dibb-backend-container-dev
@@ -27,14 +32,11 @@ services:
       - "8082:8080"
     environment:
       SPRING_PROFILES_ACTIVE: docker-dev
-      SPRING_DATASOURCE_URL: jdbc:mysql://dibb-db-dev:3306/dibb?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=UTF-8
+      SPRING_DATASOURCE_URL: jdbc:mysql://db:3306/dibb?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=UTF-8
       SPRING_DATASOURCE_USERNAME: root
       SPRING_DATASOURCE_PASSWORD: dibb2024
-      SPRING_JPA_HIBERNATE_DDL_AUTO: update
-      SPRING_JPA_PROPERTIES_HIBERNATE_DIALECT: org.hibernate.dialect.MySQLDialect
-      SPRING_JPA_SHOW_SQL: "true"
-      SPRING_JPA_PROPERTIES_HIBERNATE_FORMAT_SQL: "true"
-      SPRING_JPA_DEFER_DATASOURCE_INITIALIZATION: "true"
+      SPRING_JPA_HIBERNATE_DDL_AUTO: none
+      SPRING_JPA_DATABASE_PLATFORM: org.hibernate.dialect.MySQLDialect
     depends_on:
       db:
         condition: service_healthy
@@ -42,7 +44,6 @@ services:
       - ./src:/app/src
     networks:
       - dev-network
-    restart: unless-stopped
 
 networks:
   dev-network:

--- a/backend/src/main/resources/application-docker-dev.yml
+++ b/backend/src/main/resources/application-docker-dev.yml
@@ -1,0 +1,41 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://db:3306/dibb?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC&characterEncoding=UTF-8
+    username: root
+    password: dibb2024
+
+  jpa:
+    database-platform: org.hibernate.dialect.MySQLDialect
+    hibernate:
+      ddl-auto: none
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQLDialect
+    defer-datasource-initialization: true
+
+  sql:
+    init:
+      mode: always
+      encoding: UTF-8
+
+server:
+  port: 8080
+  servlet:
+    encoding:
+      charset: UTF-8
+      force: true
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.type: trace
+    org.springframework.security: debug
+
+security:
+  jwt:
+    header: Authorization
+    secret: c2Vqb25nLWRpYmItc3ByaW5nLWJvb3Qtand0LXNlY3JldC1rZXktc2Vqb25nLWRpYmItc3ByaW5nLWJvb3Qtand0LXNlY3JldC1rZXkK
+    token-validity-in-seconds: 86400

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -6,9 +6,16 @@ ALTER TABLE seminar AUTO_INCREMENT = 1;
 ALTER TABLE thesis AUTO_INCREMENT = 1;
 ALTER TABLE board AUTO_INCREMENT = 1;
 
--- Department 더미 데이터 (1개)
-INSERT INTO Department (department_id, educationalObjective, englishName, intro, koreanName, location, map, phone, workHour)
-VALUES (1, '컴퓨터 공학 인재 양성', 'Computer Engineering', '컴퓨터공학과 소개', '컴퓨터공학과', '본관 101호', 'https://example.com/map', '010-1234-5678', '9:00 - 18:00');
+UPDATE Department
+SET educationalObjective = '컴퓨터 공학 인재 양성',
+    englishName = 'Computer Engineering',
+    intro = '컴퓨터공학과 소개',
+    koreanName = '컴퓨터공학과',
+    location = '본관 101호',
+    map = 'https://example.com/map',
+    phone = '010-1234-5678',
+    workHour = '9:00 - 18:00'
+WHERE department_id = 1;
 
 -- Admin 더미 데이터 (1개)
 INSERT INTO admin (id, login_id, password, username, email, role)
@@ -71,4 +78,3 @@ VALUES
     (10, '열 번째 게시글', '게시글 내용 10', 100, '작성자10', 'file10.txt', '2024-01-10', 'graduate', 1);
 
 SET FOREIGN_KEY_CHECKS = 1;
-

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -1,28 +1,20 @@
-SET FOREIGN_KEY_CHECKS = 0;
+DELETE FROM board;
+DELETE FROM thesis;
+DELETE FROM seminar;
+DELETE FROM professor;
+DELETE FROM department;
+DELETE FROM admin;
 
-ALTER TABLE Department AUTO_INCREMENT = 1;
-ALTER TABLE professor AUTO_INCREMENT = 1;
-ALTER TABLE seminar AUTO_INCREMENT = 1;
-ALTER TABLE thesis AUTO_INCREMENT = 1;
-ALTER TABLE board AUTO_INCREMENT = 1;
+-- Department 더미 데이터 (1개)
+INSERT INTO department (department_id, korean_name, english_name, intro, phone, location, educational_objective, work_hour, map)
+VALUES (1, '컴퓨터공학과', 'Computer Engineering', '컴퓨터공학과 소개', '010-1234-5678', '본관 101호', '컴퓨터 공학 인재 양성', '9:00 - 18:00', 'https://example.com/map');
 
-UPDATE Department
-SET educationalObjective = '컴퓨터 공학 인재 양성',
-    englishName = 'Computer Engineering',
-    intro = '컴퓨터공학과 소개',
-    koreanName = '컴퓨터공학과',
-    location = '본관 101호',
-    map = 'https://example.com/map',
-    phone = '010-1234-5678',
-    workHour = '9:00 - 18:00'
-WHERE department_id = 1;
-
--- -- Admin 더미 데이터 (1개)
--- INSERT INTO admin (id, login_id, password, username, email, role)
--- VALUES (1, 'admin01', 'password123', '관리자', 'admin@example.com', 'ADMIN');
+-- Admin 더미 데이터 (1개)
+INSERT INTO admin (id, login_id, password, username, email, role)
+VALUES (1, 'admin01', 'password123', '관리자', 'admin@example.com', 'ADMIN');
 
 -- Professor 더미 데이터 (10개)
-INSERT INTO professor (professor_id, name, major, phone, email, position, homepage, lab, profileImage, department_id)
+INSERT INTO professor (professor_id, name, major, phone, email, position, homepage, lab, profile_image, department_id)
 VALUES
     (1, '교수1', 'AI', '010-1111-1111', 'prof1@example.com', '교수', 'https://prof1-homepage.com', 'AI 연구실', 'https://example.com/prof1.jpg', 1),
     (2, '교수2', 'Machine Learning', '010-2222-2222', 'prof2@example.com', '교수', 'https://prof2-homepage.com', 'ML 연구실', 'https://example.com/prof2.jpg', 1),
@@ -76,5 +68,3 @@ VALUES
     (8, '여덟 번째 게시글', '게시글 내용 8', 80, '작성자8', 'file8.txt', '2024-01-08', 'scholarship', 1),
     (9, '아홉 번째 게시글', '게시글 내용 9', 90, '작성자9', 'file9.txt', '2024-01-09', 'undergraduate', 1),
     (10, '열 번째 게시글', '게시글 내용 10', 100, '작성자10', 'file10.txt', '2024-01-10', 'graduate', 1);
-
-SET FOREIGN_KEY_CHECKS = 1;

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -17,9 +17,9 @@ SET educationalObjective = '컴퓨터 공학 인재 양성',
     workHour = '9:00 - 18:00'
 WHERE department_id = 1;
 
--- Admin 더미 데이터 (1개)
-INSERT INTO admin (id, login_id, password, username, email, role)
-VALUES (1, 'admin01', 'password123', '관리자', 'admin@example.com', 'ADMIN');
+-- -- Admin 더미 데이터 (1개)
+-- INSERT INTO admin (id, login_id, password, username, email, role)
+-- VALUES (1, 'admin01', 'password123', '관리자', 'admin@example.com', 'ADMIN');
 
 -- Professor 더미 데이터 (10개)
 INSERT INTO professor (professor_id, name, major, phone, email, position, homepage, lab, profileImage, department_id)

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -1,13 +1,21 @@
+SET FOREIGN_KEY_CHECKS = 0;
+
+ALTER TABLE Department AUTO_INCREMENT = 1;
+ALTER TABLE professor AUTO_INCREMENT = 1;
+ALTER TABLE seminar AUTO_INCREMENT = 1;
+ALTER TABLE thesis AUTO_INCREMENT = 1;
+ALTER TABLE board AUTO_INCREMENT = 1;
+
 -- Department 더미 데이터 (1개)
-INSERT INTO department (department_id, korean_name, english_name, intro, phone, location, educational_objective, work_hour, map)
-VALUES (1, '컴퓨터공학과', 'Computer Engineering', '컴퓨터공학과 소개', '010-1234-5678', '본관 101호', '컴퓨터 공학 인재 양성', '9:00 - 18:00', 'https://example.com/map');
+INSERT INTO Department (department_id, educationalObjective, englishName, intro, koreanName, location, map, phone, workHour)
+VALUES (1, '컴퓨터 공학 인재 양성', 'Computer Engineering', '컴퓨터공학과 소개', '컴퓨터공학과', '본관 101호', 'https://example.com/map', '010-1234-5678', '9:00 - 18:00');
 
 -- Admin 더미 데이터 (1개)
 INSERT INTO admin (id, login_id, password, username, email, role)
 VALUES (1, 'admin01', 'password123', '관리자', 'admin@example.com', 'ADMIN');
 
 -- Professor 더미 데이터 (10개)
-INSERT INTO professor (professor_id, name, major, phone, email, position, homepage, lab, profile_image, department_id)
+INSERT INTO professor (professor_id, name, major, phone, email, position, homepage, lab, profileImage, department_id)
 VALUES
     (1, '교수1', 'AI', '010-1111-1111', 'prof1@example.com', '교수', 'https://prof1-homepage.com', 'AI 연구실', 'https://example.com/prof1.jpg', 1),
     (2, '교수2', 'Machine Learning', '010-2222-2222', 'prof2@example.com', '교수', 'https://prof2-homepage.com', 'ML 연구실', 'https://example.com/prof2.jpg', 1),
@@ -61,3 +69,6 @@ VALUES
     (8, '여덟 번째 게시글', '게시글 내용 8', 80, '작성자8', 'file8.txt', '2024-01-08', 'scholarship', 1),
     (9, '아홉 번째 게시글', '게시글 내용 9', 90, '작성자9', 'file9.txt', '2024-01-09', 'undergraduate', 1),
     (10, '열 번째 게시글', '게시글 내용 10', 100, '작성자10', 'file10.txt', '2024-01-10', 'graduate', 1);
+
+SET FOREIGN_KEY_CHECKS = 1;
+


### PR DESCRIPTION
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?

## 작업 내용

# Pull Request: Docker Compose 설정 개선

## 변경 사항 요약
MySQL과 Spring Boot 애플리케이션 간의 안정적인 연결을 보장하기 위한 Docker Compose 설정 개선

## 상세 변경 내용

```yaml
version: '3'
services:
  db:
    image: mysql:8.0
    container_name: dibb-db-dev
    environment:
      MYSQL_ROOT_PASSWORD: dibb2024
      MYSQL_DATABASE: dibb
    ports:
      - "3307:3306"
    volumes:
      - db-data:/var/lib/mysql
      - ./backup.sql:/docker-entrypoint-initdb.d/backup.sql
    networks:
      - dev-network
    # 추가된 healthcheck 설정
    healthcheck:
      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-pdibb2024"]
      interval: 10s
      timeout: 5s
      retries: 5
      start_period: 30s

  backend:
    container_name: dibb-backend-container-dev
    build: .
    ports:
      - "8082:8080"
    environment:
      SPRING_PROFILES_ACTIVE: docker-dev
      SPRING_DATASOURCE_URL: jdbc:mysql://dibb-db-dev:3306/dibb?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=UTF-8
      SPRING_DATASOURCE_USERNAME: root
      SPRING_DATASOURCE_PASSWORD: dibb2024
      SPRING_JPA_HIBERNATE_DDL_AUTO: update
      # 추가된 JPA 설정
      SPRING_JPA_PROPERTIES_HIBERNATE_DIALECT: org.hibernate.dialect.MySQLDialect
      SPRING_JPA_SHOW_SQL: "true"
      SPRING_JPA_PROPERTIES_HIBERNATE_FORMAT_SQL: "true"
      SPRING_JPA_DEFER_DATASOURCE_INITIALIZATION: "true"
    depends_on:
      db:
        condition: service_healthy
    volumes:
      - ./src:/app/src
    networks:
      - dev-network
    restart: unless-stopped

networks:
  dev-network:
    driver: bridge

volumes:
  db-data:
```

## 주요 변경사항

1. **DB 헬스체크 추가**
   - MySQL 서버의 상태를 주기적으로 확인하는 healthcheck 설정 추가
   - 10초 간격으로 체크, 최대 5번 재시도
   - 초기 시작 시 30초의 유예 기간 설정

2. **JPA 설정 개선**
   - Hibernate Dialect 명시적 설정
   - SQL 로깅 활성화로 디버깅 용이성 향상
   - 문자 인코딩 UTF-8 설정

3. **의존성 관리 개선**
   - `depends_on` 조건을 healthcheck 기반으로 변경
   - DB가 완전히 준비된 후에만 백엔드 서비스 시작

4. **컨테이너 재시작 정책**
   - `restart: unless-stopped` 추가로 장애 시 자동 복구 지원


## 테스트 완료 사항
- [x] 컨테이너 정상 시작
- [x] 데이터베이스 연결 성공
- [x] JPA 엔티티 테이블 생성 확인
- [x] 장애 상황에서의 자동 복구 동작 확인

## 스크린샷
### 컨테이너 (스프링부트, db) 정상 실행 확인 
<img width="1182" alt="image" src="https://github.com/user-attachments/assets/2c0b6d68-845e-40f5-9fcf-afa9d6ae7558">


### Swagger 요청 로직 성공
<img width="1277" alt="image" src="https://github.com/user-attachments/assets/4c5156fe-ec01-4503-99c2-1e3d17d733d0">


Closes #108