### PR TITLE
[FE] 메인페이지 api 연결

### DIFF
--- a/frontend/src/config/apiConfig.ts
+++ b/frontend/src/config/apiConfig.ts
@@ -1,11 +1,18 @@
 const API_URL = process.env.REACT_APP_API_URL;
 
 export const apiEndpoints = {
+  thesis: {
+    list: `${API_URL}/api/thesis`,
+    create: `${API_URL}/api/thesis`,
+    get: (thesisId: string) => `${API_URL}/api/thesis/${thesisId}`,
+    update: (thesisId: string) => `${API_URL}/api/thesis/${thesisId}`,
+    delete: (thesisId: string) => `${API_URL}/api/thesis/${thesisId}`,
+  },
   professor: {
     create: `${API_URL}/api/professor`,
-    get: (professorId: string) => `${API_URL}/api/professor/${professorId}`,
-    update: (professorId: string) => `${API_URL}/api/professor/${professorId}`,
-    delete: (professorId: string) => `${API_URL}/api/professor/${professorId}`,
+    get: (thesisId: string) => `${API_URL}/api/professor/${thesisId}`,
+    update: (thesisId: string) => `${API_URL}/api/professor/${thesisId}`,
+    delete: (thesisId: string) => `${API_URL}/api/professor/${thesisId}`,
   },
   admin: {
     login: `${API_URL}/api/admin/login`,

--- a/frontend/src/config/apiConfig.ts
+++ b/frontend/src/config/apiConfig.ts
@@ -10,9 +10,9 @@ export const apiEndpoints = {
   },
   professor: {
     create: `${API_URL}/api/professor`,
-    get: (thesisId: string) => `${API_URL}/api/professor/${thesisId}`,
-    update: (thesisId: string) => `${API_URL}/api/professor/${thesisId}`,
-    delete: (thesisId: string) => `${API_URL}/api/professor/${thesisId}`,
+    get: (professorId: string) => `${API_URL}/api/professor/${professorId}`,
+    update: (professorId: string) => `${API_URL}/api/professor/${professorId}`,
+    delete: (professorId: string) => `${API_URL}/api/professor/${professorId}`,
   },
   admin: {
     login: `${API_URL}/api/admin/login`,

--- a/frontend/src/pages/Main/Main.tsx
+++ b/frontend/src/pages/Main/Main.tsx
@@ -20,8 +20,13 @@ import axios from 'axios';
 import { apiEndpoints } from '../../config/apiConfig';
 
 interface Announcement {
+  category: string;
+  createDate: string;
+  // file: string;
+  id: number;
   title: string;
-  date: string;
+  viewCount: number;
+  writer: string;
 }
 
 interface Paper {
@@ -37,36 +42,36 @@ interface Paper {
   thesisImage: string;
 }
 
-const announcements: { [key: string]: Announcement[] } = {
-  학부: [
-    { title: '공지사항', date: '2024.00.00' },
-    { title: '공지사항', date: '2024.00.00' },
-    { title: '공지사항', date: '2024.00.00' },
-    { title: '공지사항', date: '2024.00.00' },
-    { title: '공지사항', date: '2024.00.00' },
-  ],
-  대학원: [
-    { title: '대학원 공지사항', date: '2024.00.00' },
-    { title: '대학원 공지사항', date: '2024.00.00' },
-    { title: '대학원 공지사항', date: '2024.00.00' },
-    { title: '대학원 공지사항', date: '2024.00.00' },
-    { title: '대학원 공지사항', date: '2024.00.00' },
-  ],
-  취업: [
-    { title: '취업 공지사항', date: '2024.00.00' },
-    { title: '취업 공지사항', date: '2024.00.00' },
-    { title: '취업 공지사항', date: '2024.00.00' },
-    { title: '취업 공지사항', date: '2024.00.00' },
-    { title: '취업 공지사항', date: '2024.00.00' },
-  ],
-  장학: [
-    { title: '장학 공지사항', date: '2024.00.00' },
-    { title: '장학 공지사항', date: '2024.00.00' },
-    { title: '장학 공지사항', date: '2024.00.00' },
-    { title: '장학 공지사항', date: '2024.00.00' },
-    { title: '장학 공지사항', date: '2024.00.00' },
-  ],
-};
+// const announcements: { [key: string]: Announcement[] } = {
+//   학부: [
+//     { title: '공지사항', date: '2024.00.00' },
+//     { title: '공지사항', date: '2024.00.00' },
+//     { title: '공지사항', date: '2024.00.00' },
+//     { title: '공지사항', date: '2024.00.00' },
+//     { title: '공지사항', date: '2024.00.00' },
+//   ],
+//   대학원: [
+//     { title: '대학원 공지사항', date: '2024.00.00' },
+//     { title: '대학원 공지사항', date: '2024.00.00' },
+//     { title: '대학원 공지사항', date: '2024.00.00' },
+//     { title: '대학원 공지사항', date: '2024.00.00' },
+//     { title: '대학원 공지사항', date: '2024.00.00' },
+//   ],
+//   취업: [
+//     { title: '취업 공지사항', date: '2024.00.00' },
+//     { title: '취업 공지사항', date: '2024.00.00' },
+//     { title: '취업 공지사항', date: '2024.00.00' },
+//     { title: '취업 공지사항', date: '2024.00.00' },
+//     { title: '취업 공지사항', date: '2024.00.00' },
+//   ],
+//   장학: [
+//     { title: '장학 공지사항', date: '2024.00.00' },
+//     { title: '장학 공지사항', date: '2024.00.00' },
+//     { title: '장학 공지사항', date: '2024.00.00' },
+//     { title: '장학 공지사항', date: '2024.00.00' },
+//     { title: '장학 공지사항', date: '2024.00.00' },
+//   ],
+// };
 
 const links = [
   {
@@ -101,13 +106,15 @@ const links = [
   },
 ];
 
+const announcementTab = ['학부', '대학원', '취업', '장학'];
+
 function Main(): JSX.Element {
-  const [activeTab, setActiveTab] =
-    useState<keyof typeof announcements>('학부');
   const [papers, setPapers] = useState([]);
+  const [announcements, setAnnouncements] = useState<Announcement[]>([]);
+  const [activeTab, setActiveTab] = useState('학부');
 
   useEffect(() => {
-    const fetchData = async () => {
+    const fetchPaper = async () => {
       try {
         const response = await axios.get(apiEndpoints.thesis.list, {
           params: {
@@ -117,11 +124,27 @@ function Main(): JSX.Element {
         });
         setPapers(response.data.data);
       } catch (error) {
-        console.error('논문 데이터를 가져오는 중 오류 발생:', error);
+        console.error('논문 데이터 가져오기 실패:', error);
       }
     };
 
-    fetchData();
+    const fetchAnnouncement = async () => {
+      try {
+        const response = await axios.get(apiEndpoints.board.list, {
+          params: {
+            page: 0,
+            size: 5,
+          },
+        });
+        setAnnouncements(response.data.data);
+        console.log('announcement', response.data.data);
+      } catch (error) {
+        console.error('공지사항 데이터 가져오기 실패', error);
+      }
+    };
+
+    fetchPaper();
+    fetchAnnouncement();
   }, []);
 
   return (
@@ -146,7 +169,7 @@ function Main(): JSX.Element {
           <AnnouncementContainer>
             <p>공지사항</p>
             <TabContainer>
-              {Object.keys(announcements).map((tab) => (
+              {announcementTab.map((tab) => (
                 <TabButton
                   key={tab}
                   isActive={activeTab === tab}
@@ -157,15 +180,38 @@ function Main(): JSX.Element {
               ))}
             </TabContainer>
             <ContentContainer>
-              {announcements[activeTab].map((announcement, index) => (
-                <AnnouncementItem key={index}>
-                  <span>
-                    <img src="/bullet.svg" />
-                    <span>{announcement.title}</span>
-                  </span>
-                  <span>{announcement.date}</span>
-                </AnnouncementItem>
-              ))}
+              {announcements
+                .filter((announcement) => {
+                  // 각 탭에 해당하는 카테고리로 필터링
+                  switch (activeTab) {
+                    case '학부':
+                      return announcement.category === 'undergraduate';
+                    case '대학원':
+                      return announcement.category === 'graduate';
+                    case '취업':
+                      return announcement.category === 'employment';
+                    case '장학':
+                      return announcement.category === 'scholarship';
+                    default:
+                      return false;
+                  }
+                })
+                .map((announcement) => (
+                  <AnnouncementItem
+                    key={announcement.id}
+                    style={{
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      padding: '10px 0',
+                    }}
+                  >
+                    <span>
+                      <img src="/bullet.svg" />
+                      {announcement.title}
+                    </span>
+                    <span>{announcement.createDate}</span>
+                  </AnnouncementItem>
+                ))}
             </ContentContainer>
           </AnnouncementContainer>
           <SeminarContainer>

--- a/frontend/src/pages/Main/Main.tsx
+++ b/frontend/src/pages/Main/Main.tsx
@@ -19,16 +19,7 @@ import { useState, useEffect } from 'react';
 import axios from 'axios';
 import { apiEndpoints } from '../../config/apiConfig';
 
-interface Announcement {
-  category: string;
-  createDate: string;
-  // file: string;
-  id: number;
-  title: string;
-  viewCount: number;
-  writer: string;
-}
-
+// 논문
 interface Paper {
   author: string;
   content: string;
@@ -42,36 +33,18 @@ interface Paper {
   thesisImage: string;
 }
 
-// const announcements: { [key: string]: Announcement[] } = {
-//   학부: [
-//     { title: '공지사항', date: '2024.00.00' },
-//     { title: '공지사항', date: '2024.00.00' },
-//     { title: '공지사항', date: '2024.00.00' },
-//     { title: '공지사항', date: '2024.00.00' },
-//     { title: '공지사항', date: '2024.00.00' },
-//   ],
-//   대학원: [
-//     { title: '대학원 공지사항', date: '2024.00.00' },
-//     { title: '대학원 공지사항', date: '2024.00.00' },
-//     { title: '대학원 공지사항', date: '2024.00.00' },
-//     { title: '대학원 공지사항', date: '2024.00.00' },
-//     { title: '대학원 공지사항', date: '2024.00.00' },
-//   ],
-//   취업: [
-//     { title: '취업 공지사항', date: '2024.00.00' },
-//     { title: '취업 공지사항', date: '2024.00.00' },
-//     { title: '취업 공지사항', date: '2024.00.00' },
-//     { title: '취업 공지사항', date: '2024.00.00' },
-//     { title: '취업 공지사항', date: '2024.00.00' },
-//   ],
-//   장학: [
-//     { title: '장학 공지사항', date: '2024.00.00' },
-//     { title: '장학 공지사항', date: '2024.00.00' },
-//     { title: '장학 공지사항', date: '2024.00.00' },
-//     { title: '장학 공지사항', date: '2024.00.00' },
-//     { title: '장학 공지사항', date: '2024.00.00' },
-//   ],
-// };
+// 공지사항
+const announcementTab: string[] = ['학부', '대학원', '취업', '장학'];
+
+interface Announcement {
+  category: string;
+  createDate: string;
+  // file: string;
+  id: number;
+  title: string;
+  viewCount: number;
+  writer: string;
+}
 
 const links = [
   {
@@ -106,8 +79,6 @@ const links = [
   },
 ];
 
-const announcementTab = ['학부', '대학원', '취업', '장학'];
-
 function Main(): JSX.Element {
   const [papers, setPapers] = useState([]);
   const [announcements, setAnnouncements] = useState<Announcement[]>([]);
@@ -137,7 +108,6 @@ function Main(): JSX.Element {
           },
         });
         setAnnouncements(response.data.data);
-        console.log('announcement', response.data.data);
       } catch (error) {
         console.error('공지사항 데이터 가져오기 실패', error);
       }
@@ -215,7 +185,7 @@ function Main(): JSX.Element {
             </ContentContainer>
           </AnnouncementContainer>
           <SeminarContainer>
-            {/* TODO: 링크 연결이 필요하면 넣기 */}
+            {/* TODO: 최신 세미나 링크 연결 필요 */}
             <button>
               <p style={{ fontSize: '22px', marginBottom: '0' }}>세미나</p>
               <p style={{ fontSize: '16px', fontWeight: '700' }}>

--- a/frontend/src/pages/Main/Main.tsx
+++ b/frontend/src/pages/Main/Main.tsx
@@ -15,32 +15,27 @@ import {
   AnnouncementItem,
   SeminarRoomReservation,
 } from './MainStyle';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import axios from 'axios';
+import { apiEndpoints } from '../../config/apiConfig';
 
 interface Announcement {
   title: string;
   date: string;
 }
 
-// 더미 데이터
-const paper = [
-  {
-    title: '연구 논문1',
-    content: '연구 논문1 초반 내용',
-  },
-  {
-    title: '연구 논문2',
-    content: '연구 논문2 초반 내용',
-  },
-  {
-    title: '연구 논문3',
-    content: '연구 논문3 초반 내용',
-  },
-  {
-    title: '연구 논문4',
-    content: '연구 논문4 초반 내용',
-  },
-];
+interface Paper {
+  author: string;
+  content: string;
+  issn: string;
+  journal: string;
+  link: string;
+  publicationCollection: string;
+  publicationDate: string;
+  publicationIssue: string;
+  publicationPage: string;
+  thesisImage: string;
+}
 
 const announcements: { [key: string]: Announcement[] } = {
   학부: [
@@ -109,19 +104,37 @@ const links = [
 function Main(): JSX.Element {
   const [activeTab, setActiveTab] =
     useState<keyof typeof announcements>('학부');
+  const [papers, setPapers] = useState([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await axios.get(apiEndpoints.thesis.list, {
+          params: {
+            page: 0,
+            size: 4,
+          },
+        });
+        setPapers(response.data.data);
+      } catch (error) {
+        console.error('논문 데이터를 가져오는 중 오류 발생:', error);
+      }
+    };
+
+    fetchData();
+  }, []);
 
   return (
     <MainContainer>
       {/* 연구논문 */}
       <PaperContainer>
         <Title>연구 논문</Title>
-        {/* 더미 데이터 */}
         <div style={{ display: 'flex' }}>
-          {paper.map((item) => (
-            <Paper key={item.title}>
-              <img src="paperImage.png" />
-              <p>{item.title}</p>
-              <p>{item.content}</p>
+          {papers.map((paper: Paper) => (
+            <Paper key={paper.journal} style={{ margin: '10px' }}>
+              <img src={paper.thesisImage} alt="논문 이미지" />
+              <p>{paper.author}</p>
+              <p>{paper.content}</p>
             </Paper>
           ))}
         </div>

--- a/frontend/src/pages/Main/MainStyle.ts
+++ b/frontend/src/pages/Main/MainStyle.ts
@@ -105,12 +105,13 @@ export const AnnouncementItem = styled.div`
   cursor: pointer;
 
   img {
-    margin: 0 8px 0 20px;
+    margin: 0 8px 0 8px;
   }
 
   span {
     font-size: 15px;
     font-weight: 400;
+    margin-right: 8px;
   }
 `;
 

--- a/frontend/src/pages/Main/MainStyle.ts
+++ b/frontend/src/pages/Main/MainStyle.ts
@@ -202,7 +202,7 @@ export const Shortcut = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: 50%;
+  width: fit-content;
 
   img {
     width: 90px;


### PR DESCRIPTION
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
- 논문 4개를 서버에서 가져옴
- 각 공지탭마다 5개씩 공지사항을 서버에서 가져옴

## 작동 영상
https://github.com/user-attachments/assets/1ca8658b-a87b-40a9-9f9a-de8bdaa7376a

## 주의사항
- 서버에 저장된 논문 이미지 링크가 유효하지 않아서(더미데이터) 이미지가 뜨지 않음
- 논문 조회 페이지 구현 후 논문마다 링크 연결 필요
- 세미나 조회 페이지 구현 후 최신 세미나 버튼에 링크 연결 필요
- 논문, 공지사항 최신순으로 정렬 필요

Closes #101