### PR TITLE
[FE] [REFACTOR] 게시글 카테고리 렌더링 리펙토링

### DIFF
--- a/frontend/src/config/apiConfig.ts
+++ b/frontend/src/config/apiConfig.ts
@@ -3,6 +3,16 @@ const API_URL = process.env.REACT_APP_API_URL;
 export const apiEndpoints = {
   thesis: {
     list: `${API_URL}/api/thesis`,
+    listWithPage: (page: number, size: number, sort?: string[]) => {
+      const params = new URLSearchParams({
+        page: page.toString(),
+        size: size.toString(),
+      });
+      if (sort && sort.length > 0) {
+        sort.forEach((sortItem) => params.append('sort', sortItem));
+      }
+      return `${API_URL}/api/thesis?${params.toString()}`;
+    },
     create: `${API_URL}/api/thesis`,
     get: (thesisId: string) => `${API_URL}/api/thesis/${thesisId}`,
     update: (thesisId: string) => `${API_URL}/api/thesis/${thesisId}`,

--- a/frontend/src/config/apiConfig.ts
+++ b/frontend/src/config/apiConfig.ts
@@ -69,17 +69,9 @@ export const apiEndpoints = {
     get: `${API_URL}/api/`,
   },
   board: {
-    list: `${API_URL}/api/board`,
-    listWithPage: (page: number, size: number, category?: string) => {
-      const params = new URLSearchParams({
-        page: page.toString(),
-        size: size.toString(),
-      });
-      if (category) {
-        params.append('category', category);
-      }
-      return `${API_URL}/api/board?${params.toString()}`;
-    },
+    base: `${API_URL}/api/board`,
+    listWithPage: (page: number, size: number) =>
+      `${API_URL}/api/board?page=${page}&size=${size}`,
     create: `${API_URL}/api/board`,
     get: (boardId: string) => `${API_URL}/api/board/${boardId}`,
     update: (boardId: string) => `${API_URL}/api/board/${boardId}`,

--- a/frontend/src/pages/News/NoticeBoard/NoticeBoard.tsx
+++ b/frontend/src/pages/News/NoticeBoard/NoticeBoard.tsx
@@ -34,7 +34,6 @@ interface NoticeItem {
   file?: string;
 }
 
-// Category mapping updated with explicit English keys
 const CATEGORY_MAP = {
   undergraduate: '학부',
   graduate: '대학원',
@@ -44,7 +43,6 @@ const CATEGORY_MAP = {
 
 type CategoryKey = keyof typeof CATEGORY_MAP;
 
-// Added type safety for notice types
 const NOTICE_TYPES = ['전체', ...Object.values(CATEGORY_MAP)] as const;
 
 interface PageInfo {
@@ -74,7 +72,6 @@ const NoticeBoard: React.FC = () => {
     size: 5,
   });
 
-  // Convert Korean category to English
   const getEnglishCategory = (koreanType: string): CategoryKey | undefined => {
     if (koreanType === '전체') return undefined;
     const entry = Object.entries(CATEGORY_MAP).find(
@@ -83,7 +80,6 @@ const NoticeBoard: React.FC = () => {
     return entry ? (entry[0] as CategoryKey) : undefined;
   };
 
-  // Convert English category to Korean for display
   const getCategoryLabel = (category: string): string => {
     return CATEGORY_MAP[category as CategoryKey] || category;
   };

--- a/frontend/src/pages/News/NoticeBoard/NoticeBoard.tsx
+++ b/frontend/src/pages/News/NoticeBoard/NoticeBoard.tsx
@@ -34,24 +34,18 @@ interface NoticeItem {
   file?: string;
 }
 
-const CATEGORY_MAP: { [key: string]: string } = {
+// Category mapping updated with explicit English keys
+const CATEGORY_MAP = {
   undergraduate: '학부',
   graduate: '대학원',
   employment: '취업',
   scholarship: '장학',
-};
-const NOTICE_TYPES = ['전체', '학부', '대학원', '취업', '장학'];
+} as const;
 
-const REVERSE_CATEGORY_MAP: { [key: string]: string } = {
-  학부: 'undergraduate',
-  대학원: 'graduate',
-  취업: 'employment',
-  장학: 'scholarship',
-};
+type CategoryKey = keyof typeof CATEGORY_MAP;
 
-const getEnglishCategory = (koreanType: string): string | undefined => {
-  return REVERSE_CATEGORY_MAP[koreanType];
-};
+// Added type safety for notice types
+const NOTICE_TYPES = ['전체', ...Object.values(CATEGORY_MAP)] as const;
 
 interface PageInfo {
   currentPage: number;
@@ -66,48 +60,6 @@ interface ApiResponse {
   data: NoticeItem[];
 }
 
-// 더미데이터 생성 함수 유지
-
-/*
-const generateDummyNotices = (
-    page: number,
-    size: number,
-    type: string,
-): ApiResponse => {
-  const totalItems = 23;
-  const totalPages = Math.ceil(totalItems / size);
-  const startIndex = page * size;
-
-  const dummyData = Array.from(
-      { length: Math.min(size, totalItems - startIndex) },
-      (_, index) => {
-        const id = startIndex + index + 1;
-        const category =
-            type === '전체'
-                ? ['학부', '대학원'][Math.floor(Math.random() * 2)]
-                : type;
-
-        return {
-          id: id,
-          title: `${category} 공지사항 ${id}`,
-          content: `게시글 내용 ${id}`,
-          viewCount: Math.floor(Math.random() * 100),
-          writer: `작성자${Math.floor(Math.random() * 5) + 1}`,
-          createDate: new Date(2024, 0, id).toISOString().split('T')[0],
-          category: category,
-        };
-      },
-  );
-
-  return {
-    message: '조회성공',
-    page: page,
-    totalPage: totalPages,
-    data: dummyData,
-  };
-};
-*/
-
 const NoticeBoard: React.FC = () => {
   const navigate = useNavigate();
   const auth = useContext(AuthContext);
@@ -115,15 +67,25 @@ const NoticeBoard: React.FC = () => {
   const [notices, setNotices] = useState<NoticeItem[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [selectedType, setSelectedType] = useState('전체');
+  const [selectedType, setSelectedType] = useState<string>('전체');
   const [pageInfo, setPageInfo] = useState<PageInfo>({
     currentPage: 0,
     totalPages: 0,
     size: 5,
   });
 
+  // Convert Korean category to English
+  const getEnglishCategory = (koreanType: string): CategoryKey | undefined => {
+    if (koreanType === '전체') return undefined;
+    const entry = Object.entries(CATEGORY_MAP).find(
+      ([_, value]) => value === koreanType,
+    );
+    return entry ? (entry[0] as CategoryKey) : undefined;
+  };
+
+  // Convert English category to Korean for display
   const getCategoryLabel = (category: string): string => {
-    return CATEGORY_MAP[category] || category;
+    return CATEGORY_MAP[category as CategoryKey] || category;
   };
 
   const fetchNotices = async (page = 0) => {
@@ -131,12 +93,12 @@ const NoticeBoard: React.FC = () => {
     setError(null);
 
     try {
-      const category =
-        selectedType !== '전체' ? getEnglishCategory(selectedType) : undefined;
+      const category = getEnglishCategory(selectedType);
+      const endpoint = category
+        ? `${apiEndpoints.board.base}/category/${category}?page=${page}&size=${pageInfo.size}`
+        : apiEndpoints.board.listWithPage(page, pageInfo.size);
 
-      const response = await axios.get<ApiResponse>(
-        apiEndpoints.board.listWithPage(page, pageInfo.size, category),
-      );
+      const response = await axios.get<ApiResponse>(endpoint);
 
       setNotices(response.data.data);
       setPageInfo({
@@ -144,7 +106,7 @@ const NoticeBoard: React.FC = () => {
         totalPages: response.data.totalPage,
         size: pageInfo.size,
       });
-    } catch (error: any) {
+    } catch (error) {
       console.error('Failed to fetch notices:', error);
       setError('게시글을 불러오는데 실패했습니다.');
     } finally {
@@ -225,6 +187,7 @@ const NoticeBoard: React.FC = () => {
       </PaginationContainer>
     );
   };
+
   return (
     <Container>
       <HeaderContainer>
@@ -290,4 +253,5 @@ const NoticeBoard: React.FC = () => {
     </Container>
   );
 };
+
 export default NoticeBoard;

--- a/frontend/src/pages/News/NoticeBoard/NoticeBoardStyle.ts
+++ b/frontend/src/pages/News/NoticeBoard/NoticeBoardStyle.ts
@@ -114,16 +114,17 @@ export const Table = styled.table`
   border-collapse: collapse;
   font-size: 1rem;
   background-color: #fff;
+  text-align: center;
 `;
 
 export const Th = styled.th`
   padding: 16px 24px;
-  text-align: left;
   border-top: 1px solid #ddd;
   border-bottom: 1px solid #ddd;
   font-weight: 600;
   color: #333;
   background-color: #f8f9fa;
+  text-align: center;
 
   ${media.mobile} {
     padding: 12px 16px;
@@ -135,6 +136,7 @@ export const Td = styled.td`
   padding: 16px 24px;
   border-bottom: 1px solid #ddd;
   line-height: 1.5;
+  text-align: center;
 
   ${media.mobile} {
     padding: 12px 16px;
@@ -163,6 +165,7 @@ export const TitleLink = styled.span`
   cursor: pointer;
   font-weight: 500;
   color: #333;
+  text-align: left;
 
   &:hover {
     color: #666;


### PR DESCRIPTION
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?

## 작업 내용
# Pull Request: 학과 홈페이지 개선 사항 구현

## 변경 사항 개요
1. 게시판 카테고리 필터링 API 연동 구현
2. 논문 섹션 수평 스크롤 레이아웃 구현
3. 공지사항 게시판 테이블 정렬 개선

## 상세 변경 내용
### 전체
<img width="914" alt="image" src="https://github.com/user-attachments/assets/3fc89c8e-f97e-4db8-8dcd-6a6309601830">
### 카테고리 적용
<img width="916" alt="image" src="https://github.com/user-attachments/assets/1a7ed9fe-e20a-44af-b320-46abf3d94ea9">
### api
<img width="708" alt="image" src="https://github.com/user-attachments/assets/49b4e5ba-cc9e-47fa-bc80-4e4fa18ff2ef">
<img width="706" alt="image" src="https://github.com/user-attachments/assets/519768ca-7bdf-44ae-a7c9-484a588f368e">


### 1. 게시판 카테고리 필터링 개선
```typescript
const CATEGORY_MAP = {
  undergraduate: '학부',
  graduate: '대학원',
  employment: '취업',
  scholarship: '장학',
} as const;

// API 엔드포인트 호출 로직
const fetchNotices = async (page = 0) => {
  const category = getEnglishCategory(selectedType);
  const endpoint = category
    ? `${apiEndpoints.board.base}/category/${category}?page=${page}&size=${pageInfo.size}`
    : apiEndpoints.board.listWithPage(page, pageInfo.size);

  const response = await axios.get<ApiResponse>(endpoint);
  // ...
};
```
- 카테고리 매핑 상수 정의
- 백엔드 API 명세에 맞춘 엔드포인트 구조 변경
- 타입 안정성 강화

### 3. 공지사항 게시판 테이블 정렬 개선
- 테이블 셀 중앙 정렬 기본값 설정
- 제목 열은 좌측 정렬 유지
- 조회수 열은 우측 정렬 유지


## 테스트 항목
- [x] 카테고리별 게시글 필터링 정상 작동
- [x] 테이블 정렬 일관성 확인
- [x] 페이지네이션 정상 작동 확인


Closes #135 