### PR TITLE
#117 test: 더미데이터 사용 캘린더 예약 현황 렌더링 테스트

### DIFF
--- a/frontend/src/pages/SeminarRoom/Reservation.tsx
+++ b/frontend/src/pages/SeminarRoom/Reservation.tsx
@@ -18,6 +18,44 @@ import moment, { Moment, MomentInput } from 'moment';
 
 const seminarRooms: string[] = ['세미나실1', '세미나실2'];
 
+// 더미 데이터 타입 정의
+interface Reservation {
+  id: number;
+  roomId: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+  userName: string;
+  purpose: 'SEMINAR' | 'STUDY' | 'MEETING' | 'OTHER';
+  contact: string;
+  department?: string;
+}
+
+// 더미 데이터
+const dummyReservations: Reservation[] = [
+  {
+    id: 1,
+    roomId: '세미나실1',
+    date: '2024-11-16',
+    startTime: '09:00',
+    endTime: '11:00',
+    userName: '김철수',
+    purpose: 'SEMINAR',
+    contact: '010-1234-5678',
+    department: '컴퓨터공학과',
+  },
+  {
+    id: 2,
+    roomId: '세미나실1',
+    date: '2024-11-16',
+    startTime: '13:00',
+    endTime: '15:00',
+    userName: '이영희',
+    purpose: 'STUDY',
+    contact: '010-2345-6789',
+  },
+];
+
 function Reservation() {
   const [selectedRoom, setSelectedRoom] = useState('세미나실1');
   const [selectedDate, setSelectedDate] = useState(
@@ -34,6 +72,64 @@ function Reservation() {
 
   const handleDateChange = (date: MomentInput) => {
     setSelectedDate(moment(date).format('YYYY년 MM월 DD일'));
+  };
+
+  const tileContent = ({ date }: { date: Date }) => {
+    const formattedDate = moment(date).format('YYYY-MM-DD');
+    const reservationsForDate = dummyReservations.filter(
+      (reservation) =>
+        reservation.date === formattedDate &&
+        reservation.roomId === selectedRoom,
+    );
+
+    if (reservationsForDate.length === 0) return null;
+
+    return (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          fontSize: '8px',
+          marginTop: '2px',
+        }}
+      >
+        {reservationsForDate.map((reservation, index) => (
+          <div
+            key={index}
+            style={{
+              backgroundColor: getColorByPurpose(reservation.purpose),
+              padding: '1px',
+              margin: '1px',
+              borderRadius: '2px',
+              color: 'white',
+            }}
+          >
+            {reservation.startTime}~{reservation.endTime}
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  const getColorByPurpose = (purpose: string) => {
+    const colors = {
+      SEMINAR: '#1a73e8',
+      STUDY: '#34d399',
+      MEETING: '#f59e0b',
+      OTHER: '#9ca3af',
+    };
+    return colors[purpose as keyof typeof colors] || colors.OTHER;
+  };
+
+  // 예약이 있는 날짜의 스타일 지정
+  const tileClassName = ({ date }: { date: Date }) => {
+    const formattedDate = moment(date).format('YYYY-MM-DD');
+    const hasReservations = dummyReservations.some(
+      (reservation) =>
+        reservation.date === formattedDate &&
+        reservation.roomId === selectedRoom,
+    );
+    return hasReservations ? 'has-reservation' : '';
   };
 
   return (
@@ -81,6 +177,8 @@ function Reservation() {
         next2Label={null}
         minDetail="year"
         onChange={handleDateChange}
+        tileContent={tileContent}
+        tileClassName={tileClassName}
       />
     </Container>
   );


### PR DESCRIPTION
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?

## 작업 내용
캘린더 예약 현황 렌더링 테스트 

PR(Pull Request) 문서를 작성해드리겠습니다:

```markdown
# [Feature] 세미나실 예약 캘린더 이벤트 렌더링 구현

## 📝 PR 내용
세미나실 예약 시스템의 캘린더 뷰에 예약 현황을 시각적으로 표시하는 기능을 구현했습니다.

## 🔍 주요 변경사항

### 1. 데이터 구조 정의
```typescript
interface Reservation {
  id: number;
  roomId: string;
  date: string;
  startTime: string;
  endTime: string;
  userName: string;
  purpose: 'SEMINAR' | 'STUDY' | 'MEETING' | 'OTHER';
  contact: string;
  department?: string;
}
```

### 2. 구현 기능
- 날짜별 예약 현황 시각화
- 예약 목적별 색상 구분
- 룸별 필터링 지원
- 예약 시간대 표시

### 3. UI/UX 개선
- 예약이 있는 날짜 강조 표시
- 컴팩트한 예약 정보 표시
- 직관적인 색상 코드 적용

## 📸 스크린샷
[캘린더 뷰 스크린샷 첨부]
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/763b1b47-c162-41c6-9ab9-305d622a2cab">



## 🗒 참고 사항
- 현재는 더미데이터를 사용중이며, 추후 API 연동 예정
- 예약 생성/수정/삭제 기능은 다음 PR에서 구현 예정
