### PR TITLE
[FE] 푸터 반응형 디자인 레이아웃 개선

### DIFF
--- a/frontend/src/components/Footer/FooterStyle.ts
+++ b/frontend/src/components/Footer/FooterStyle.ts
@@ -1,80 +1,120 @@
-// styles.ts
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
+
+const media = {
+  mobile: '@media(max-width: 768px)',
+  tablet: '@media(max-width: 1024px)',
+};
 
 export const Footer = styled.footer`
   width: 100%;
   padding: 40px;
   background-color: #d7e8ff;
-
-  /* 1180px 미만일 때 */
-  @media (max-width: 1180px) {
-    width: 100%;
-  }
-
-  /* 휴대폰 */
-  @media (max-width: 768px) {
-    width: 100%;
-  }
   box-sizing: border-box;
+
+  ${media.tablet} {
+    padding: 24px 40px;
+  }
+
+  ${media.mobile} {
+    padding: 24px 40px;
+  }
 `;
 
 export const FooterContainer = styled.div`
   display: flex;
+  justify-content: space-between;
 
-  @media (max-width: 768px) {
-    display: flex;
-    flex-direction: column;
+  ${media.tablet} {
+    flex-direction: column; /* 태블릿에서는 세로 정렬 */
+    align-items: center;
+    gap: 20px;
   }
-  box-sizing: border-box;
+
+  ${media.mobile} {
+    flex-direction: column;
+    align-items: center;
+    gap: 20px;
+  }
 `;
 
 export const Address = styled.div`
-  flex: 1 0 0;
+  flex: 1;
   font-size: 16px;
   font-weight: 500;
   font-family: 'Plus Jakarta Sans';
 
-  @media (max-width: 768px) {
-    margin-bottom: 20px;
+  ${media.tablet} {
+    text-align: center;
+    font-size: 15px;
+  }
+
+  ${media.mobile} {
+    text-align: center;
+    font-size: 14px;
+    line-height: 1.5; /* 텍스트 줄 간격 조정 */
   }
 `;
 
 export const AddressTitle = styled.div`
-  font-size: 32px;
+  font-size: 22px;
   font-weight: 600;
-  margin: 0 0 20px 0;
+  margin: 0 0 12px 0;
 `;
 
 export const SightMap = styled.div`
   display: flex;
-  flex: 2 0 0;
-  cursor: pointer;
+  flex: 2;
+  gap: 20px;
 
-  @media (max-width: 768px) {
-    flex-direction: column;
+  ${media.tablet} {
+    display: grid; /* grid 레이아웃 사용 */
+    grid-template-columns: repeat(2, 1fr); /* 2열 레이아웃 */
+    gap: 20px;
+    justify-items: center; /* 중앙 정렬 */
+  }
+
+  ${media.mobile} {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 10px;
+    justify-items: center;
   }
 `;
 
 export const SightMapHeader = styled.div`
-  display: flex;
-  flex-direction: column;
   flex-grow: 1;
   margin-right: 20px;
-  font-size: 20px;
+  font-size: 18px;
   font-family: 'Noto Serif KR', serif;
   font-weight: 600;
 
-  @media (max-width: 768px) {
-    flex-direction: row;
+  ${media.tablet} {
+    margin-right: 0;
+    text-align: center;
+    font-size: 16px;
+  }
+
+  ${media.mobile} {
+    margin-right: 0;
+    font-size: 15px;
+    text-align: center;
   }
 `;
 
-export const SightMapContent = styled.a`
+export const SightMapContent = styled.div`
   font-size: 16px;
   font-weight: 300;
-  margin-top: 16px;
+  margin-top: 8px;
   font-family: 'Noto Sans';
+
+  ${media.tablet} {
+    display: none;
+  }
+
+  ${media.mobile} {
+    display: none; /* 모바일에서 숨기기 */
+  }
 `;
 
 export const Copyright = styled.div`
@@ -84,9 +124,34 @@ export const Copyright = styled.div`
   margin-top: 36px;
   padding-top: 36px;
   font-weight: 600;
+  text-align: center;
+
+  span {
+    flex: 1; /* 왼쪽 영역을 채우도록 설정 */
+    text-align: left; /* 카피라이트 왼쪽 정렬 */
+    align-content: center;
+    font-size: 14px;
+
+    ${media.mobile} {
+      font-size: 12px;
+      text-align: center;
+      line-height: 1.4;
+    }
+  }
+
+  ${media.tablet} {
+    flex-direction: column; /* 태블릿에서 세로 정렬 */
+    align-items: center;
+    text-align: center;
+  }
+
+  ${media.mobile} {
+    flex-direction: column; /* 모바일에서 세로 정렬 */
+    align-items: center;
+    text-align: center;
+  }
 `;
 
-// 기본 스타일을 없앤 Link 컴포넌트
 export const StyledLink = styled(Link)`
   text-decoration: none;
   color: inherit;
@@ -95,11 +160,18 @@ export const StyledLink = styled(Link)`
 export const AdminSection = styled.div`
   display: flex;
   align-items: center;
-  gap: 1rem;
+  justify-content: center;
   color: #333;
 
   span {
     font-size: 0.9rem;
+    display: inline-block; /* 내용이 부모 안에 포함되도록 설정 */
+    white-space: nowrap; /* 텍스트 줄바꿈 방지 */
+    padding: 8px;
+
+    ${media.mobile} {
+      max-width: 70%;
+    }
   }
 `;
 
@@ -112,11 +184,14 @@ export const AdminButton = styled.button`
   gap: 0.5rem;
   padding: 0.5rem;
   color: inherit;
+  white-space: nowrap;
+  width: auto; /* 버튼 크기를 텍스트에 맞게 조정 */
 
   img {
-    width: 8vw;
-    height: 3vh;
+    width: 24px;
+    height: 24px;
   }
+
   svg {
     width: 24px;
     height: 24px;

--- a/frontend/src/components/Footer/FooterStyle.ts
+++ b/frontend/src/components/Footer/FooterStyle.ts
@@ -188,8 +188,17 @@ export const AdminButton = styled.button`
   width: auto; /* 버튼 크기를 텍스트에 맞게 조정 */
 
   img {
-    width: 24px;
-    height: 24px;
+    width: 108px;
+    height: auto;
+
+    ${media.tablet} {
+      margin-top: 8px;
+    }
+
+    ${media.mobile} {
+      width: 92px;
+      margin-top: 8px;
+    }
   }
 
   svg {


### PR DESCRIPTION
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
- `FooterContainer`: 세로 정렬로 변경
- `Address`: 텍스트를 중앙 정렬하고 글씨 크기를 조정
- `SightMap`: 그리드로 변경
- `SightMapContent`: 숨김
- `Copyright`: 중앙 정렬 및 텍스트 크기 축소
- `AdminButton`: 버튼 크기와 아이콘 크기 조정
- 반응형 디자인은 CSS @media 쿼리를 사용

## 스크린샷
**[태블릿]**
![image](https://github.com/user-attachments/assets/62246b6d-d1de-45b6-862f-fa197ea95035)
<br>

**[모바일]**
![image](https://github.com/user-attachments/assets/456a4e1b-dfaf-473a-990f-c74d13a693a3)


Closes #158 