### PR TITLE
[FE] 메인 페이지에서 특정 공지사항 클릭 시 해당 공지사항 페이지로 이동

### DIFF
--- a/frontend/src/pages/Main/Main.tsx
+++ b/frontend/src/pages/Main/Main.tsx
@@ -17,6 +17,7 @@ import {
   SeminarRoomReservation,
 } from './MainStyle';
 import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { apiEndpoints } from '../../config/apiConfig';
 
@@ -96,6 +97,7 @@ const links = [
 ];
 
 function Main(): JSX.Element {
+  const navigate = useNavigate();
   const [papers, setPapers] = useState<Paper[]>([]);
   const [announcements, setAnnouncements] = useState<Announcement[]>([]);
   const [activeTab, setActiveTab] = useState('학부');
@@ -150,6 +152,11 @@ function Main(): JSX.Element {
     }
   };
 
+  // 특정 공지사항 페이지로 이동
+  const handleAnnouncementClick = (id: number) => {
+    navigate(`/news/noticeboard/${id}`);
+  };
+
   return (
     <MainContainer>
       {/* 연구논문 */}
@@ -193,6 +200,7 @@ function Main(): JSX.Element {
                 announcements.map((announcement) => (
                   <AnnouncementItem
                     key={announcement.id}
+                    onClick={() => handleAnnouncementClick(announcement.id)}
                     style={{
                       display: 'flex',
                       justifyContent: 'space-between',


### PR DESCRIPTION
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
- useNavigate를 이용해 메인 페이지에서 특정 공지사항을 클릭 시 해당 공지사항 페이지로 이동하는 기능 구현 

## 스크린샷
![image](https://github.com/user-attachments/assets/740e7cdf-251d-4916-8707-df56c59c9eea)
![localhost_3000_news_noticeboard_10](https://github.com/user-attachments/assets/7ececbe1-48fd-4210-bd13-ddd06e98d681)

## 주의사항

Closes #200 