### PR TITLE
[FE] [FEAT] 게시판 리스트 등록일 정렬 기능 추가 

### DIFF
--- a/frontend/src/pages/News/NoticeBoard/NoticeBoard.tsx
+++ b/frontend/src/pages/News/NoticeBoard/NoticeBoard.tsx
@@ -188,7 +188,13 @@ const NoticeBoard: React.FC = () => {
               제목
             </S.SortableTh>
             <S.Th>작성자</S.Th>
-            <S.Th>등록일</S.Th>
+            <S.SortableTh
+              onClick={() => handleSort('createdDate')}
+              isActive={filters.sort.field === 'createdDate'}
+              sortDirection={filters.sort.direction}
+            >
+              등록일
+            </S.SortableTh>{' '}
             <S.Th>카테고리</S.Th>
             <S.SortableTh
               onClick={() => handleSort('viewCount')}

--- a/frontend/src/pages/News/NoticeBoard/hooks/useNoticeBoard.ts
+++ b/frontend/src/pages/News/NoticeBoard/hooks/useNoticeBoard.ts
@@ -21,7 +21,7 @@ export const useNoticeBoard = () => {
     filters: {
       category: 'all',
       sort: {
-        field: 'createDate',
+        field: 'createdDate',
         direction: 'desc',
       },
       page: 0,
@@ -55,6 +55,7 @@ export const useNoticeBoard = () => {
         'content',
         'writer',
         'viewCount',
+        'createdDate',
       ];
 
       if (allowedSortFields.includes(state.filters.sort.field)) {

--- a/frontend/src/pages/News/NoticeBoard/types/notice.types.ts
+++ b/frontend/src/pages/News/NoticeBoard/types/notice.types.ts
@@ -45,4 +45,5 @@ export type SortField =
   | 'content'
   | 'writer'
   | 'viewCount'
-  | 'createDate';
+  | 'createDate'
+  | 'createdDate';


### PR DESCRIPTION
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
명세에 맞게 정렬기능 추가

기본 리스트 렌더링 시 등록일 최신순으로 정렬됨


## 스크린샷
## 기본 정렬된 상태
![image](https://github.com/user-attachments/assets/e1157446-a71f-485a-99ca-22a66e6273ce)
## 날짜 오름차순 정렬 (오래된 순)
![image](https://github.com/user-attachments/assets/8c2df60a-7f8b-44bf-aa8b-0cc4f3f39f22)

## 주의사항
게시글의 프로퍼티명과 정렬 기능의 프로퍼티명 다름
게시글 : createDate
정려 : createdDate