### PR TITLE
[FE] [FEAT] 뉴스 CRUD, 뉴스 슬라이더 구현

### DIFF
--- a/frontend/src/AppContent.tsx
+++ b/frontend/src/AppContent.tsx
@@ -40,6 +40,7 @@ import SeminarDetail from './pages/Seminar/SeminarDetail';
 import SeminarCreate from './pages/Seminar/SeminarCreate';
 import SeminarEdit from './pages/Seminar/SeminarEdit';
 import News from './pages/News/News/News';
+import NewsDetail from './pages/News/News/NewsDetail';
 
 interface PageTransitionProps {
   children: React.ReactNode;
@@ -214,7 +215,6 @@ function AppContent() {
               <Route path="/about/organization" element={<Organization />} />
 
               {/* news */}
-              <Route path="/news" element={<News />} />
               <Route path="/news/noticeboard" element={<NoticeBoard />} />
               <Route path="/news/noticeboard/:id" element={<NoticeDetail />} />
               <Route
@@ -225,6 +225,9 @@ function AppContent() {
               <Route path="/news/seminar/:id" element={<SeminarDetail />} />
               <Route path="/news/thesis" element={<ThesisList />} />
               <Route path="/news/thesis/:id" element={<ThesisDetail />} />
+              {/*학부 뉴스*/}
+              <Route path="/news" element={<News />} />
+              <Route path="/news/:newsId" element={<NewsDetail />} />
 
               {/* 어드민 권한 보호 Routes */}
               <Route

--- a/frontend/src/AppContent.tsx
+++ b/frontend/src/AppContent.tsx
@@ -41,6 +41,7 @@ import SeminarCreate from './pages/Seminar/SeminarCreate';
 import SeminarEdit from './pages/Seminar/SeminarEdit';
 import News from './pages/News/News/News';
 import NewsDetail from './pages/News/News/NewsDetail';
+import NewsCreate from './pages/News/News/NewsCreate';
 
 interface PageTransitionProps {
   children: React.ReactNode;
@@ -291,6 +292,14 @@ function AppContent() {
                 element={
                   <ProtectedRoute requireAuth requireAdmin>
                     <SeminarEdit />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/news/create"
+                element={
+                  <ProtectedRoute requireAuth requireAdmin>
+                    <NewsCreate />
                   </ProtectedRoute>
                 }
               />

--- a/frontend/src/AppContent.tsx
+++ b/frontend/src/AppContent.tsx
@@ -42,6 +42,7 @@ import SeminarEdit from './pages/Seminar/SeminarEdit';
 import News from './pages/News/News/News';
 import NewsDetail from './pages/News/News/NewsDetail';
 import NewsCreate from './pages/News/News/NewsCreate';
+import NewsEdit from './pages/News/News/NewsEdit';
 
 interface PageTransitionProps {
   children: React.ReactNode;
@@ -300,6 +301,14 @@ function AppContent() {
                 element={
                   <ProtectedRoute requireAuth requireAdmin>
                     <NewsCreate />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/news/edit/:newsId"
+                element={
+                  <ProtectedRoute requireAuth requireAdmin>
+                    <NewsEdit />
                   </ProtectedRoute>
                 }
               />

--- a/frontend/src/AppContent.tsx
+++ b/frontend/src/AppContent.tsx
@@ -39,6 +39,7 @@ import SeminarList from './pages/Seminar/SeminarList';
 import SeminarDetail from './pages/Seminar/SeminarDetail';
 import SeminarCreate from './pages/Seminar/SeminarCreate';
 import SeminarEdit from './pages/Seminar/SeminarEdit';
+import News from './pages/News/News/News';
 
 interface PageTransitionProps {
   children: React.ReactNode;
@@ -201,7 +202,10 @@ function AppContent() {
 
               {/* graduate */}
               <Route path="graduate/overview" element={<GraduateOverview />} />
-              <Route path="graduate/curriculum" element={<GraduateCurriculum />} />
+              <Route
+                path="graduate/curriculum"
+                element={<GraduateCurriculum />}
+              />
 
               {/* about */}
               <Route path="/about" element={<Overview />} />
@@ -210,6 +214,7 @@ function AppContent() {
               <Route path="/about/organization" element={<Organization />} />
 
               {/* news */}
+              <Route path="/news" element={<News />} />
               <Route path="/news/noticeboard" element={<NoticeBoard />} />
               <Route path="/news/noticeboard/:id" element={<NoticeDetail />} />
               <Route

--- a/frontend/src/components/Footer/Footer.tsx
+++ b/frontend/src/components/Footer/Footer.tsx
@@ -55,7 +55,6 @@ function renderSightMapSections() {
       contents: [
         { name: '소개', link: '/graduate/overview' },
         { name: '교과과정', link: '/graduate/curriculum' },
-        { name: '학칙/규정', link: '/graduate/rules' },
       ],
     },
     {

--- a/frontend/src/components/Footer/Footer.tsx
+++ b/frontend/src/components/Footer/Footer.tsx
@@ -60,8 +60,9 @@ function renderSightMapSections() {
     },
     {
       title: '바융소식',
-      titleLink: '/news/noticeboard',
+      titleLink: '/news',
       contents: [
+        { name: '학부뉴스', link: '/news' },
         { name: '공지사항', link: '/news/noticeboard' },
         { name: '세미나', link: '/news' },
         { name: '연구논문', link: '/news/thesis' },

--- a/frontend/src/components/Header/Navigation/Navigation.tsx
+++ b/frontend/src/components/Header/Navigation/Navigation.tsx
@@ -60,8 +60,9 @@ const navigationItems: NavigationItem[] = [
   },
   {
     title: '바융소식',
-    path: '/news/noticeboard',
+    path: '/news',
     menuItems: [
+      { name: '학부 뉴스', path: '/news' },
       { name: '공지사항', path: '/news/noticeboard' },
       { name: '세미나', path: '/news/seminar' },
       { name: '연구논문', path: '/news/thesis' },

--- a/frontend/src/components/Header/Navigation/Navigation.tsx
+++ b/frontend/src/components/Header/Navigation/Navigation.tsx
@@ -1,4 +1,3 @@
-// Navigation.tsx
 import React, { useState, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useResponsive } from '../../../hooks/useResponsive';
@@ -61,7 +60,7 @@ const navigationItems: NavigationItem[] = [
     title: '바융소식',
     path: '/news',
     menuItems: [
-      { name: '학부 뉴스', path: '/news' },
+      { name: '학부뉴스', path: '/news' },
       { name: '공지사항', path: '/news/noticeboard' },
       { name: '세미나', path: '/news/seminar' },
       { name: '연구논문', path: '/news/thesis' },

--- a/frontend/src/components/Header/Navigation/Navigation.tsx
+++ b/frontend/src/components/Header/Navigation/Navigation.tsx
@@ -55,7 +55,6 @@ const navigationItems: NavigationItem[] = [
     menuItems: [
       { name: '소개', path: '/graduate/overview' },
       { name: '교과과정', path: '/graduate/curriculum' },
-      { name: '학칙/규정', path: '/graduate/rules' },
     ],
   },
   {

--- a/frontend/src/components/Header/Navigation/NavigationStyle.ts
+++ b/frontend/src/components/Header/Navigation/NavigationStyle.ts
@@ -1,4 +1,3 @@
-// NavigationStyle.ts
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 

--- a/frontend/src/components/Header/constants.ts
+++ b/frontend/src/components/Header/constants.ts
@@ -29,9 +29,10 @@ export const navItems = [
   },
   {
     title: '바융소식',
-    path: '/news/noticeboard',
+    path: '/news',
     menuItems: [
-      { name: '공지사항', path: '/news/noticeboard' },
+      { name: '학부 뉴스', path: '/news' },
+      { name: '공지 사항', path: '/news/noticeboard' },
       { name: '세미나', path: '/news/seminar' },
       { name: '연구 논문', path: '/news/thesis' },
     ],

--- a/frontend/src/components/NewsSlider/NewsCard.tsx
+++ b/frontend/src/components/NewsSlider/NewsCard.tsx
@@ -1,0 +1,57 @@
+// NewsCard.tsx
+import React from 'react';
+import moment from 'moment';
+import { Eye } from 'lucide-react'; // 조회수 아이콘 추가
+import {
+  NewsCardWrapper,
+  NewsImage,
+  NewsContent,
+  NewsTitle,
+  NewsDate,
+  NewsFooter,
+  ViewCount,
+} from './NewsSliderStyle';
+
+interface NewsCardProps {
+  id: number;
+  title: string;
+  createDate: string;
+  image: string;
+  view: number; // 조회수 추가
+  imageBaseUrl: string; // 이미지 base URL 추가
+  onClick: (id: number) => void;
+}
+
+const NewsCard: React.FC<NewsCardProps> = ({
+  id,
+  title,
+  createDate,
+  image,
+  view,
+  imageBaseUrl,
+  onClick,
+}) => {
+  return (
+    <NewsCardWrapper onClick={() => onClick?.(id)}>
+      <NewsImage
+        imageUrl={`${imageBaseUrl}/${image}`}
+        onError={(e: React.SyntheticEvent<HTMLDivElement>) => {
+          e.currentTarget.style.backgroundColor = '#f1f1f1';
+          e.currentTarget.innerHTML = '이미지를 불러올 수 없습니다';
+        }}
+      />
+      <NewsContent>
+        <NewsTitle>{title}</NewsTitle>
+        <NewsFooter>
+          <NewsDate>{moment(createDate).format('YYYY.MM.DD')}</NewsDate>
+          <ViewCount>
+            <Eye size={16} />
+            {view}
+          </ViewCount>
+        </NewsFooter>
+      </NewsContent>
+    </NewsCardWrapper>
+  );
+};
+
+export default NewsCard;

--- a/frontend/src/components/NewsSlider/NewsSlider.tsx
+++ b/frontend/src/components/NewsSlider/NewsSlider.tsx
@@ -1,0 +1,130 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  SliderContainer,
+  SliderTrack,
+  PrevButton,
+  NextButton,
+} from './NewsSliderStyle';
+import NewsCard from './NewsCard';
+import SliderControls from './SliderControls';
+import { ChevronLeft, ChevronRight } from 'lucide-react'; // 아이콘 import
+
+export interface NewsItem {
+  id: number;
+  title: string;
+  content: string;
+  createDate: string;
+  image: string;
+  category?: string;
+}
+
+interface NewsSliderProps {
+  news: Array<{
+    id: number;
+    title: string;
+    content: string;
+    createDate: string;
+    image: string;
+    view: number;
+    category?: string;
+  }>;
+  autoPlayInterval?: number;
+  onNewsClick: (id: number) => void;
+}
+
+const NewsSlider: React.FC<NewsSliderProps> = ({
+  news,
+  autoPlayInterval = 5000,
+  onNewsClick,
+}) => {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isPaused, setIsPaused] = useState(false);
+
+  const getItemsPerView = () => {
+    if (typeof window === 'undefined') return 4;
+    if (window.innerWidth <= 480) return 1;
+    if (window.innerWidth <= 768) return 2;
+    if (window.innerWidth <= 1024) return 3;
+    return 4;
+  };
+
+  const IMAGE_BASE_URL =
+    'https://dibb-bucket.s3.ap-northeast-2.amazonaws.com/news';
+
+  const [itemsPerView, setItemsPerView] = useState(getItemsPerView());
+
+  useEffect(() => {
+    const handleResize = () => {
+      setItemsPerView(getItemsPerView());
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  const maxIndex = Math.max(0, news.length - itemsPerView);
+
+  const handlePrev = useCallback(() => {
+    setCurrentIndex((prev) => Math.max(0, prev - 1));
+  }, []);
+
+  const handleNext = useCallback(() => {
+    setCurrentIndex((prev) => Math.min(maxIndex, prev + 1));
+  }, [maxIndex]);
+
+  useEffect(() => {
+    if (!isPaused && autoPlayInterval) {
+      const interval = setInterval(() => {
+        if (currentIndex >= maxIndex) {
+          setCurrentIndex(0);
+        } else {
+          handleNext();
+        }
+      }, autoPlayInterval);
+
+      return () => clearInterval(interval);
+    }
+  }, [currentIndex, maxIndex, handleNext, isPaused, autoPlayInterval]);
+
+  return (
+    <SliderContainer
+      onMouseEnter={() => setIsPaused(true)}
+      onMouseLeave={() => setIsPaused(false)}
+    >
+      <SliderTrack
+        transform={`translateX(-${currentIndex * (100 / itemsPerView)}%)`}
+      >
+        {news.map((item) => (
+          <NewsCard
+            key={item.id}
+            id={item.id}
+            title={item.title}
+            createDate={item.createDate}
+            image={item.image}
+            view={item.view || 0} // view가 없을 경우 기본값 0
+            imageBaseUrl={IMAGE_BASE_URL} // 이미지 base URL 추가
+            onClick={onNewsClick}
+          />
+        ))}
+      </SliderTrack>
+
+      <PrevButton
+        onClick={handlePrev}
+        disabled={currentIndex === 0}
+        aria-label="Previous slide"
+      >
+        <ChevronLeft size={24} />
+      </PrevButton>
+
+      <NextButton
+        onClick={handleNext}
+        disabled={currentIndex >= maxIndex}
+        aria-label="Next slide"
+      >
+        <ChevronRight size={24} />
+      </NextButton>
+    </SliderContainer>
+  );
+};
+
+export default NewsSlider;

--- a/frontend/src/components/NewsSlider/NewsSliderStyle.ts
+++ b/frontend/src/components/NewsSlider/NewsSliderStyle.ts
@@ -1,62 +1,80 @@
-// NewsSliderStyle.ts
 import styled from 'styled-components';
 
-// 컨테이너 스타일
+const media = {
+  tablet: '@media(max-width: 1024px)',
+  mobile: '@media(max-width: 768px)',
+  small: '@media(max-width: 480px)',
+};
+
 export const SliderContainer = styled.div`
   width: 100%;
   position: relative;
   overflow: hidden;
-  padding: 20px 0;
-`;
+  padding: 20px;
+  max-width: 1200px;
+  margin: 0 auto;
 
+  ${media.mobile} {
+    padding: 16px;
+  }
+`;
 export const SliderTrack = styled.div<{ transform: string }>`
   display: flex;
   gap: 20px;
   transition: transform 0.5s ease-in-out;
   transform: ${(props) => props.transform};
-`;
+  width: 100%;
 
-// 뉴스 카드 스타일
+  ${media.mobile} {
+    gap: 16px;
+    padding: 0 20px;
+  }
+`;
 export const NewsCardWrapper = styled.div`
-  flex: 0 0 calc(25% - 15px);
+  width: 100%;
+  max-width: 300px;
+  margin: 0 auto;
   background: white;
   border-radius: 8px;
   overflow: hidden;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  transition: transform 0.3s ease;
-  cursor: pointer;
 
-  &:hover {
-    transform: translateY(-5px);
-  }
-
-  @media (max-width: 1024px) {
-    flex: 0 0 calc(33.333% - 14px);
-  }
-
-  @media (max-width: 768px) {
-    flex: 0 0 calc(50% - 10px);
-  }
-
-  @media (max-width: 480px) {
-    flex: 0 0 100%;
+  ${media.mobile} {
+    max-width: 100%;
+    margin: 0;
   }
 `;
 
 export const NewsImage = styled.div<{ imageUrl: string }>`
   width: 100%;
-  height: 200px;
+  height: 180px;
   background-image: url(${(props) => props.imageUrl});
   background-size: cover;
   background-position: center;
+
+  ${media.tablet} {
+    height: 160px;
+  }
+
+  ${media.mobile} {
+    height: 140px;
+  }
+
+  ${media.small} {
+    height: 180px;
+  }
 `;
 
 export const NewsContent = styled.div`
   padding: 16px;
+
+  ${media.mobile} {
+    padding: 12px;
+  }
 `;
 
 export const NewsTitle = styled.h3`
-  margin: 0 0 8px 0;
+  margin: 0;
   font-size: 16px;
   font-weight: 600;
   line-height: 1.4;
@@ -65,59 +83,41 @@ export const NewsTitle = styled.h3`
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
+
+  ${media.mobile} {
+    font-size: 14px;
+    height: 40px;
+  }
+
+  ${media.small} {
+    font-size: 15px;
+    height: 42px;
+  }
+`;
+
+export const NewsFooter = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 12px;
+
+  ${media.mobile} {
+    margin-top: 8px;
+  }
 `;
 
 export const NewsDate = styled.p`
   margin: 0;
   font-size: 14px;
   color: #666;
-`;
 
-// 컨트롤 버튼 스타일
-const BaseButton = styled.button`
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  background: white;
-  border: 1px solid #ddd;
-  border-radius: 50%;
-  width: 40px;
-  height: 40px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  z-index: 2;
-  transition: all 0.2s ease;
-
-  &:hover {
-    background: #f5f5f5;
-    border-color: #999;
+  ${media.mobile} {
+    font-size: 12px;
   }
 
-  &:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
+  ${media.small} {
+    font-size: 13px;
   }
-
-  @media (max-width: 768px) {
-    width: 32px;
-    height: 32px;
-  }
-`;
-
-export const PrevButton = styled(BaseButton)`
-  left: 10px;
-`;
-
-export const NextButton = styled(BaseButton)`
-  right: 10px;
-`;
-export const NewsFooter = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-top: 8px;
 `;
 
 export const ViewCount = styled.div`
@@ -129,5 +129,73 @@ export const ViewCount = styled.div`
 
   svg {
     color: #999;
+    width: 16px;
+    height: 16px;
+  }
+
+  ${media.mobile} {
+    font-size: 12px;
+
+    svg {
+      width: 14px;
+      height: 14px;
+    }
+  }
+
+  ${media.small} {
+    font-size: 13px;
+  }
+`;
+
+const BaseButton = styled.button`
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: white;
+  border: 1px solid #ddd;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 2;
+  transition: all 0.2s ease;
+
+  &:hover:not(:disabled) {
+    background: #f5f5f5;
+    border-color: #999;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  ${media.mobile} {
+    width: 32px;
+    height: 32px;
+  }
+
+  ${media.small} {
+    width: 28px;
+    height: 28px;
+  }
+`;
+
+export const PrevButton = styled(BaseButton)`
+  left: 10px;
+
+  ${media.small} {
+    left: 5px;
+  }
+`;
+
+export const NextButton = styled(BaseButton)`
+  right: 10px;
+
+  ${media.small} {
+    right: 5px;
   }
 `;

--- a/frontend/src/components/NewsSlider/NewsSliderStyle.ts
+++ b/frontend/src/components/NewsSlider/NewsSliderStyle.ts
@@ -1,0 +1,133 @@
+// NewsSliderStyle.ts
+import styled from 'styled-components';
+
+// 컨테이너 스타일
+export const SliderContainer = styled.div`
+  width: 100%;
+  position: relative;
+  overflow: hidden;
+  padding: 20px 0;
+`;
+
+export const SliderTrack = styled.div<{ transform: string }>`
+  display: flex;
+  gap: 20px;
+  transition: transform 0.5s ease-in-out;
+  transform: ${(props) => props.transform};
+`;
+
+// 뉴스 카드 스타일
+export const NewsCardWrapper = styled.div`
+  flex: 0 0 calc(25% - 15px);
+  background: white;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  transition: transform 0.3s ease;
+  cursor: pointer;
+
+  &:hover {
+    transform: translateY(-5px);
+  }
+
+  @media (max-width: 1024px) {
+    flex: 0 0 calc(33.333% - 14px);
+  }
+
+  @media (max-width: 768px) {
+    flex: 0 0 calc(50% - 10px);
+  }
+
+  @media (max-width: 480px) {
+    flex: 0 0 100%;
+  }
+`;
+
+export const NewsImage = styled.div<{ imageUrl: string }>`
+  width: 100%;
+  height: 200px;
+  background-image: url(${(props) => props.imageUrl});
+  background-size: cover;
+  background-position: center;
+`;
+
+export const NewsContent = styled.div`
+  padding: 16px;
+`;
+
+export const NewsTitle = styled.h3`
+  margin: 0 0 8px 0;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1.4;
+  height: 44px;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+`;
+
+export const NewsDate = styled.p`
+  margin: 0;
+  font-size: 14px;
+  color: #666;
+`;
+
+// 컨트롤 버튼 스타일
+const BaseButton = styled.button`
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: white;
+  border: 1px solid #ddd;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 2;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background: #f5f5f5;
+    border-color: #999;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  @media (max-width: 768px) {
+    width: 32px;
+    height: 32px;
+  }
+`;
+
+export const PrevButton = styled(BaseButton)`
+  left: 10px;
+`;
+
+export const NextButton = styled(BaseButton)`
+  right: 10px;
+`;
+export const NewsFooter = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 8px;
+`;
+
+export const ViewCount = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: #666;
+  font-size: 14px;
+
+  svg {
+    color: #999;
+  }
+`;

--- a/frontend/src/components/NewsSlider/SliderControls.tsx
+++ b/frontend/src/components/NewsSlider/SliderControls.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { PrevButton, NextButton } from './NewsSliderStyle';
+
+interface SliderControlsProps {
+  onPrevClick: () => void;
+  onNextClick: () => void;
+  isPrevDisabled: boolean;
+  isNextDisabled: boolean;
+}
+
+const SliderControls: React.FC<SliderControlsProps> = ({
+  onPrevClick,
+  onNextClick,
+  isPrevDisabled,
+  isNextDisabled,
+}) => {
+  return (
+    <>
+      <PrevButton
+        onClick={onPrevClick}
+        disabled={isPrevDisabled}
+        aria-label="Previous slide"
+      >
+        <ChevronLeft size={24} />
+      </PrevButton>
+
+      <NextButton
+        onClick={onNextClick}
+        disabled={isNextDisabled}
+        aria-label="Next slide"
+      >
+        <ChevronRight size={24} />
+      </NextButton>
+    </>
+  );
+};
+
+export default SliderControls;

--- a/frontend/src/config/apiConfig.ts
+++ b/frontend/src/config/apiConfig.ts
@@ -1,5 +1,13 @@
 const API_URL = process.env.REACT_APP_API_URL;
 
+export interface NewsReqDto {
+  title: string;
+  content: string;
+  link: string;
+  image: string;
+  createDate: string;
+}
+
 export interface BoardReqDto {
   title: string;
   content: string;
@@ -52,6 +60,51 @@ export interface SeminarDto {
 }
 
 export const apiEndpoints = {
+  news: {
+    list: `${API_URL}/api/news`,
+    listWithPage: (page: number, size: number) => {
+      const params = new URLSearchParams({
+        page: page.toString(),
+        size: size.toString(),
+      });
+      return `${API_URL}/api/news?${params.toString()}`;
+    },
+    create: {
+      url: `${API_URL}/api/news`,
+      getFormData: (newsReqDto: NewsReqDto, imageFile?: File | null) => {
+        const formData = new FormData();
+        formData.append(
+          'newsReqDto',
+          new Blob([JSON.stringify(newsReqDto)], {
+            type: 'application/json',
+          }),
+        );
+        if (imageFile) {
+          formData.append('news_image', imageFile);
+        }
+        return formData;
+      },
+    },
+    get: (newsId: string | number) => `${API_URL}/api/news/${newsId}`,
+    update: {
+      url: (newsId: string | number) => `${API_URL}/api/news/${newsId}`,
+      getFormData: (newsReqDto: NewsReqDto, imageFile?: File | null) => {
+        const formData = new FormData();
+        formData.append(
+          'newsReqDto',
+          new Blob([JSON.stringify(newsReqDto)], {
+            type: 'application/json',
+          }),
+        );
+        if (imageFile) {
+          formData.append('news_image', imageFile);
+        }
+        return formData;
+      },
+    },
+    delete: (newsId: string | number) => `${API_URL}/api/news/${newsId}`,
+  },
+
   thesis: {
     list: `${API_URL}/api/thesis`,
     listWithPage: (page: number, size: number, sort?: string[]) => {
@@ -68,20 +121,15 @@ export const apiEndpoints = {
       url: `${API_URL}/api/thesis`,
       getFormData: (thesisReqDto: ThesisReqDto, imageFile?: File | null) => {
         const formData = new FormData();
-
-        // thesisReqDto를 JSON 문자열로 변환하여 추가
         formData.append(
           'thesisReqDto',
           new Blob([JSON.stringify(thesisReqDto)], {
             type: 'application/json',
           }),
         );
-
-        // thesis_image 추가
         if (imageFile) {
           formData.append('thesis_image', imageFile);
         }
-
         return formData;
       },
     },
@@ -124,18 +172,15 @@ export const apiEndpoints = {
         imageFile?: File | null,
       ) => {
         const formData = new FormData();
-
         formData.append(
           'professorReqDto',
           new Blob([JSON.stringify(professorReqDto)], {
             type: 'application/json',
           }),
         );
-
         if (imageFile) {
           formData.append('profileImage', imageFile);
         }
-
         return formData;
       },
     },
@@ -146,18 +191,15 @@ export const apiEndpoints = {
         imageFile?: File | null,
       ) => {
         const formData = new FormData();
-
         formData.append(
           'professorReqDto',
           new Blob([JSON.stringify(professorReqDto)], {
             type: 'application/json',
           }),
         );
-
         if (imageFile) {
           formData.append('profile_image', imageFile);
         }
-
         return formData;
       },
     },
@@ -189,25 +231,30 @@ export const apiEndpoints = {
 
     detail: (professorId: number) => `${API_URL}/api/professor/${professorId}`,
   },
+
   admin: {
     login: `${API_URL}/api/admin/login`,
     signOut: `${API_URL}/api/admin/signOut`,
     register: `${API_URL}/api/admin/join`,
   },
+
   user: {
     login: `${API_URL}/api/user/login`,
     signOut: `${API_URL}/logout`,
     register: `${API_URL}/register`,
   },
+
   department: {
     get: (id: string) => `${API_URL}/api/departments/${id}`,
     update: (id: string) => `${API_URL}/api/departments/${id}`,
     delete: (id: string) => `${API_URL}/api/departments/${id}`,
     create: `${API_URL}/api/departments`,
   },
+
   main: {
     get: `${API_URL}/api/`,
   },
+
   board: {
     base: `${API_URL}/api/board`,
     download: `${API_URL}/api/board/download`,
@@ -215,11 +262,8 @@ export const apiEndpoints = {
       `${API_URL}/api/board?page=${page}&size=${size}`,
     create: {
       url: `${API_URL}/api/board`,
-      // API 명세에 맞게 요청 형식 지정
       getFormData: (boardReqDto: BoardReqDto, files: File[]) => {
         const formData = new FormData();
-
-        // boardReqDto를 JSON 문자열로 변환하여 추가
         formData.append(
           'boardReqDto',
           JSON.stringify({
@@ -231,12 +275,9 @@ export const apiEndpoints = {
             departmentId: 1,
           }),
         );
-
-        // boardFiles 추가
         files.forEach((file) => {
           formData.append('boardFiles', file);
         });
-
         return formData;
       },
     },

--- a/frontend/src/constants/colors.ts
+++ b/frontend/src/constants/colors.ts
@@ -1,6 +1,8 @@
 export const SEJONG_COLORS = {
   CRIMSON_RED: '#a31432',
   GRAY: '#51626F',
+  DARK_RED: '#8B0000', // 더 어두운 레드 추가
+  RED: '#E53E3E', // 일반 레드 추가
   COOL_GRAY: '#D5D6D2',
   WARM_GRAY1: '#B7B1A9',
   WARM_GRAY2: '#837259',

--- a/frontend/src/constants/pageContents.ts
+++ b/frontend/src/constants/pageContents.ts
@@ -68,7 +68,7 @@ export const PAGE_CONTENTS = {
     },
   },
   news: {
-    title: '바융소식',
+    title: '학부 뉴스',
     description: '바이오융합공학전공의 최신 소식과 연구 성과를 전달합니다',
     image: newsImg,
     path: '/news',

--- a/frontend/src/hooks/useScrollToTop.ts
+++ b/frontend/src/hooks/useScrollToTop.ts
@@ -7,7 +7,7 @@ export const useScrollToTop = () => {
   useEffect(() => {
     window.scroll({
       top: 0,
-      behavior: 'smooth'
+      behavior: 'smooth',
     });
   }, [pathname]);
 };

--- a/frontend/src/pages/Main/Main.tsx
+++ b/frontend/src/pages/Main/Main.tsx
@@ -1,13 +1,15 @@
+//Main.tsx
 import {
   MainContainer,
   PaperContainer,
   TMP,
   Title,
+  NewsTitle,
+  Paper,
   AnnouncementAndSeminar,
   AnnouncementContainer,
   SeminarContainer,
   ShortcutContainer,
-  Paper,
   Shortcut,
   ContentWrapper,
   TabContainer,
@@ -15,11 +17,13 @@ import {
   ContentContainer,
   AnnouncementItem,
   SeminarRoomReservation,
+  NewsSection,
 } from './MainStyle';
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { apiEndpoints } from '../../config/apiConfig';
+import NewsSlider from '../../components/NewsSlider/NewsSlider';
 
 interface ApiResponse<T> {
   message: string;
@@ -27,6 +31,7 @@ interface ApiResponse<T> {
   totalPage: number;
   data: T[];
 }
+
 // 논문
 interface Paper {
   title: string;
@@ -42,6 +47,17 @@ interface Paper {
   thesisImage: string;
 }
 
+// 뉴스
+interface NewsItem {
+  id: number;
+  title: string;
+  content: string;
+  createDate: string;
+  image: string;
+  view: number;
+  category?: string;
+}
+
 const CATEGORY_MAP = {
   학부: 'undergraduate',
   대학원: 'graduate',
@@ -51,13 +67,11 @@ const CATEGORY_MAP = {
 
 type CategoryKey = (typeof CATEGORY_MAP)[keyof typeof CATEGORY_MAP];
 
-// 공지사항
 const announcementTab: string[] = ['학부', '대학원', '취업', '장학'];
 
 interface Announcement {
   category: string;
   createDate: string;
-  // file: string;
   id: number;
   title: string;
   viewCount: number;
@@ -100,6 +114,7 @@ const links = [
 function Main(): JSX.Element {
   const navigate = useNavigate();
   const [papers, setPapers] = useState<Paper[]>([]);
+  const [news, setNews] = useState<NewsItem[]>([]);
   const [announcements, setAnnouncements] = useState<Announcement[]>([]);
   const [activeTab, setActiveTab] = useState('학부');
   const [loading, setLoading] = useState(false);
@@ -114,7 +129,12 @@ function Main(): JSX.Element {
         );
         setPapers(paperResponse.data.data);
 
-        // 초기 카테고리(학부)의 공지사항 로드
+        // 뉴스 데이터 로드
+        const newsResponse = await axios.get<ApiResponse<NewsItem>>(
+          apiEndpoints.news.listWithPage(0, 8),
+        );
+        setNews(newsResponse.data.data);
+
         await fetchAnnouncementsByCategory(CATEGORY_MAP.학부);
       } catch (err) {
         console.error('초기 데이터 로드 실패:', err);
@@ -145,7 +165,6 @@ function Main(): JSX.Element {
     }
   };
 
-  // 탭 변경 핸들러
   const handleTabChange = (tab: string) => {
     setActiveTab(tab);
     const categoryKey = CATEGORY_MAP[tab as keyof typeof CATEGORY_MAP];
@@ -154,18 +173,17 @@ function Main(): JSX.Element {
     }
   };
 
-  // 특정 공지사항 페이지로 이동
   const handleAnnouncementClick = (id: number) => {
     navigate(`/news/noticeboard/${id}`);
   };
 
-  const handlePaperClick = (id: number) => {
-    navigate(`/news/thesis/${id}`);
+  const handleNewsClick = (id: number) => {
+    navigate(`/news/${id}`);
   };
 
   return (
     <MainContainer>
-      {/* 연구논문 */}
+      {/* 연구논문 섹션 */}
       <PaperContainer>
         <Title>연구 논문</Title>
         <TMP>
@@ -196,7 +214,6 @@ function Main(): JSX.Element {
       </PaperContainer>
 
       <ContentWrapper>
-        {/* 공지사항, 세미나 */}
         <AnnouncementAndSeminar>
           <AnnouncementContainer>
             <p>공지사항</p>
@@ -223,11 +240,6 @@ function Main(): JSX.Element {
                   <AnnouncementItem
                     key={announcement.id}
                     onClick={() => handleAnnouncementClick(announcement.id)}
-                    style={{
-                      display: 'flex',
-                      justifyContent: 'space-between',
-                      padding: '10px 0',
-                    }}
                   >
                     <span>
                       <img src="/bullet.svg" alt="bullet" />
@@ -239,8 +251,8 @@ function Main(): JSX.Element {
               )}
             </ContentContainer>
           </AnnouncementContainer>
+
           <SeminarContainer>
-            {/* TODO: 최신 세미나 링크 연결 필요 */}
             <button>
               <p>세미나</p>
               <p>최신 세미나 제목</p>
@@ -251,19 +263,18 @@ function Main(): JSX.Element {
                 <br />
                 최신 세미나 진행 장소
               </div>
-              <img src="info.svg" />
+              <img src="info.svg" alt="info" />
             </button>
             <SeminarRoomReservation to="/seminar-rooms/reservation">
               <span>
                 세미나실 <br />
                 예약
               </span>
-              <img src="/whiteCalendarIcon.svg" />
+              <img src="/whiteCalendarIcon.svg" alt="calendar" />
             </SeminarRoomReservation>
           </SeminarContainer>
         </AnnouncementAndSeminar>
 
-        {/* 바로가기 */}
         <ShortcutContainer>
           {links.map((item) => (
             <a
@@ -272,14 +283,27 @@ function Main(): JSX.Element {
               target="_blank"
               rel="noopener noreferrer"
             >
-              <Shortcut key={item.title}>
-                <img src={item.icon} />
+              <Shortcut>
+                <img src={item.icon} alt={item.title} />
                 {item.title}
               </Shortcut>
             </a>
           ))}
         </ShortcutContainer>
       </ContentWrapper>
+
+      {/* 뉴스 슬라이더 섹션 */}
+      <NewsSection>
+        <NewsTitle>DIBB NEWS</NewsTitle>
+        <p style={{ textAlign: 'center', color: '#666', marginBottom: '40px' }}>
+          바이오융학공학전공의 주요 새소식을 전해드립니다.
+        </p>
+        <NewsSlider
+          news={news}
+          autoPlayInterval={5000}
+          onNewsClick={handleNewsClick}
+        />
+      </NewsSection>
     </MainContainer>
   );
 }

--- a/frontend/src/pages/Main/MainStyle.ts
+++ b/frontend/src/pages/Main/MainStyle.ts
@@ -1,3 +1,4 @@
+//MainStyle.ts
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import * as token from '../../constants/colors';
@@ -24,6 +25,22 @@ export const PaperContainer = styled.section`
   padding: 0 20px;
 `;
 
+export const NewsSection = styled.section`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  max-width: 1600px;
+  margin: 0 auto 40px;
+  padding: 40px 20px;
+  background-color: #f8f9fa;
+
+  ${media.mobile} {
+    padding: 20px;
+    margin-bottom: 20px;
+  }
+`;
+
 export const TMP = styled.div`
   display: flex;
   justify-content: center;
@@ -40,7 +57,7 @@ export const TMP = styled.div`
   }
 `;
 
-export const Title = styled.div`
+export const Title = styled.h2`
   margin: 50px 0 40px 0;
   font-size: 30px;
   font-weight: 700;
@@ -53,6 +70,22 @@ export const Title = styled.div`
   ${media.mobile} {
     margin: 30px 0 20px 0;
     font-size: 24px;
+  }
+`;
+
+export const NewsTitle = styled.h2`
+  margin: 0 0 20px 0;
+  font-size: 36px;
+  font-weight: 700;
+  color: ${token.SEJONG_COLORS.CRIMSON_RED};
+  text-align: center;
+
+  ${media.tablet} {
+    font-size: 32px;
+  }
+
+  ${media.mobile} {
+    font-size: 28px;
   }
 `;
 
@@ -110,13 +143,6 @@ export const Paper = styled.article`
     text-overflow: ellipsis;
     height: 54px;
   }
-
-  p:nth-of-type(2) {
-    font-size: 16px;
-    font-weight: 500;
-    color: #7a7a7a;
-  }
-
   p:nth-of-type(3) {
     font-size: 14px;
     font-weight: 400;
@@ -214,16 +240,22 @@ interface TabButtonProps {
 
 export const TabButton = styled.button<TabButtonProps>`
   flex: 1;
-  padding: 12px 0 12px 0;
+  padding: 12px 0;
   background: ${({ isActive }) =>
     isActive ? `${token.SEJONG_COLORS.CRIMSON_RED}` : '#F1F1F3'};
   border: ${({ isActive }) =>
     isActive ? `1px solid ${token.SEJONG_COLORS.CRIMSON_RED}` : 'none'};
+  color: ${({ isActive }) => (isActive ? 'white' : '#333')};
   font-family: 'Noto Sans KR';
   font-size: 16px;
   font-weight: 400;
   cursor: pointer;
-  transition: background-color 0.5s;
+  transition: all 0.3s ease;
+
+  &:hover {
+    background: ${({ isActive }) =>
+      isActive ? token.SEJONG_COLORS.CRIMSON_RED : '#e9e9eb'};
+  }
 `;
 
 export const ContentContainer = styled.div``;
@@ -234,9 +266,14 @@ export const AnnouncementItem = styled.div`
   padding: 16px 0;
   border-bottom: 1px solid #e2e3e5;
   cursor: pointer;
+  transition: background-color 0.2s ease;
+
+  &:hover {
+    background-color: #f8f9fa;
+  }
 
   img {
-    margin: 0 8px 0 8px;
+    margin: 0 8px;
   }
 
   span {
@@ -249,7 +286,6 @@ export const AnnouncementItem = styled.div`
     flex-shrink: 1;
     flex-basis: 100%;
     max-width: calc(100% - 80px);
-
     display: -webkit-box;
     -webkit-line-clamp: 1;
     -webkit-box-orient: vertical;
@@ -260,6 +296,7 @@ export const AnnouncementItem = styled.div`
 
   span:last-of-type {
     width: 60px;
+    text-align: right;
   }
 `;
 
@@ -282,9 +319,14 @@ export const SeminarContainer = styled.div`
     color: white;
     font-family: 'Noto Sans KR';
     cursor: pointer;
+    transition: background-color 0.3s ease;
+
+    &:hover {
+      background-color: ${token.SEJONG_COLORS.WARM_GRAY2};
+    }
 
     p {
-      margin: 16px 0 16px 0;
+      margin: 16px 0;
 
       ${media.mobile} {
         margin: 0 0 0 8px;
@@ -297,8 +339,7 @@ export const SeminarContainer = styled.div`
 
       ${media.mobile} {
         font-size: 16px;
-        margin-top: 10px;
-        margin-bottom: 10px;
+        margin: 10px 0;
       }
     }
 
@@ -363,10 +404,15 @@ export const SeminarRoomReservation = styled(Link)`
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 0 24px 0 24px;
+  padding: 0 24px;
   font-size: 22px;
   background-color: ${token.SEJONG_COLORS.WARM_GRAY1};
   text-decoration: none;
+  transition: background-color 0.3s ease;
+
+  &:hover {
+    background-color: ${token.SEJONG_COLORS.WARM_GRAY2};
+  }
 
   span {
     margin-right: 20px;
@@ -399,7 +445,7 @@ export const ShortcutContainer = styled.section`
   grid-template-rows: repeat(3, auto);
   grid-template-columns: repeat(2, 1fr);
   gap: 50px 0;
-  padding: 95px 0 95px 0;
+  padding: 95px 0;
   background-color: #e9dfda;
 
   a {
@@ -424,10 +470,14 @@ export const Shortcut = styled.div`
   flex-direction: column;
   align-items: center;
   width: fit-content;
+  padding: 10px;
+  border-radius: 8px;
+  transition: background-color 0.2s ease;
 
   img {
     width: 90px;
     height: auto;
+    margin-bottom: 10px;
 
     ${media.tablet} {
       width: 80px;

--- a/frontend/src/pages/Main/MainStyle.ts
+++ b/frontend/src/pages/Main/MainStyle.ts
@@ -1,4 +1,3 @@
-//MainStyle.ts
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import * as token from '../../constants/colors';
@@ -9,7 +8,18 @@ const media = {
 };
 
 export const MainContainer = styled.div`
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 16px;
+
+  ${media.tablet} {
+    max-width: 90%;
+  }
+
   ${media.mobile} {
+    max-width: 100%;
+    padding: 0 12px;
     display: flex;
     flex-direction: column;
   }
@@ -20,24 +30,22 @@ export const PaperContainer = styled.section`
   flex-direction: column;
   align-items: center;
   width: 100%;
-  max-width: 1600px;
+  max-width: 1200px;
   margin: 0 auto;
-  padding: 0 20px;
-`;
+  padding: 20px;
 
+  ${media.mobile} {
+    padding: 16px;
+  }
+`;
 export const NewsSection = styled.section`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
   width: 100%;
-  max-width: 1600px;
-  margin: 0 auto 40px;
+  max-width: 1200px;
+  margin: 0 auto;
   padding: 40px 20px;
-  background-color: #f8f9fa;
 
   ${media.mobile} {
     padding: 20px;
-    margin-bottom: 20px;
   }
 `;
 
@@ -45,7 +53,7 @@ export const TMP = styled.div`
   display: flex;
   justify-content: center;
   flex-wrap: wrap;
-  gap: 40px;
+  gap: 24px;
   width: 100%;
 
   ${media.tablet} {
@@ -53,39 +61,41 @@ export const TMP = styled.div`
   }
 
   ${media.mobile} {
-    gap: 15px;
+    gap: 16px;
   }
 `;
 
 export const Title = styled.h2`
-  margin: 50px 0 40px 0;
-  font-size: 30px;
+  margin: 40px 0 32px 0;
+  font-size: 28px;
   font-weight: 700;
   color: #5d5a88;
 
   ${media.tablet} {
-    margin: 40px 0 30px 0;
-    font-size: 28px;
-  }
-  ${media.mobile} {
-    margin: 30px 0 20px 0;
     font-size: 24px;
+    margin: 32px 0 24px 0;
+  }
+
+  ${media.mobile} {
+    font-size: 22px;
+    margin: 24px 0 20px 0;
   }
 `;
 
 export const NewsTitle = styled.h2`
-  margin: 0 0 20px 0;
-  font-size: 36px;
+  margin: 0 0 16px 0;
+  font-size: 32px;
   font-weight: 700;
   color: ${token.SEJONG_COLORS.CRIMSON_RED};
   text-align: center;
 
   ${media.tablet} {
-    font-size: 32px;
+    font-size: 28px;
   }
 
   ${media.mobile} {
-    font-size: 28px;
+    font-size: 24px;
+    margin: 0 0 12px 0;
   }
 `;
 
@@ -97,10 +107,10 @@ export const Paper = styled.article`
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: 320px;
-  padding: 24px;
+  width: 280px;
+  padding: 20px;
   border: solid 1px #d4d2e3;
-  border-radius: 24px;
+  border-radius: 16px;
   background-color: white;
 
   &:hover {
@@ -109,13 +119,13 @@ export const Paper = styled.article`
   }
 
   img {
-    width: 272px;
+    width: 240px;
     height: auto;
     margin-bottom: 16px;
-    border-radius: 12px;
+    border-radius: 8px;
 
     ${media.tablet} {
-      width: 220px;
+      width: 200px;
     }
 
     ${media.mobile} {
@@ -124,59 +134,49 @@ export const Paper = styled.article`
   }
 
   p {
-    width: 272px;
+    width: 100%;
     margin: 0;
     margin-bottom: 8px;
-    font-family: 'Noto Sans KR';
     color: #5d5a88;
     word-break: break-all;
   }
 
   p:nth-of-type(1) {
-    font-size: 18px;
+    font-size: 16px;
     font-weight: 700;
     line-height: 1.5;
     display: -webkit-box;
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
     overflow: hidden;
-    text-overflow: ellipsis;
-    height: 54px;
+    height: 48px;
   }
+
+  p:nth-of-type(2) {
+    font-size: 14px;
+  }
+
   p:nth-of-type(3) {
     font-size: 14px;
-    font-weight: 400;
     color: #9e9e9e;
   }
 
   ${media.tablet} {
-    width: calc(50% - 30px);
-    max-width: 280px;
-    padding: 20px;
-
-    p {
-      width: 220px;
-    }
+    width: 240px;
+    padding: 16px;
   }
 
   ${media.mobile} {
-    width: calc(100% - 30px);
-    max-width: 240px;
-    padding: 16px;
-
-    p {
-      width: 160px;
-    }
+    width: 100%;
+    max-width: 200px;
+    padding: 12px;
 
     p:nth-of-type(1) {
-      font-size: 16px;
-      height: 48px;
-    }
-
-    p:nth-of-type(2) {
       font-size: 14px;
+      height: 42px;
     }
 
+    p:nth-of-type(2),
     p:nth-of-type(3) {
       font-size: 12px;
     }
@@ -186,52 +186,69 @@ export const Paper = styled.article`
 export const ContentWrapper = styled.section`
   display: flex;
   justify-content: space-around;
-  margin-top: 48px;
-  margin-bottom: 50px;
+  margin: 48px auto;
+  padding: 0 20px;
+  max-width: 1200px;
+  gap: 24px;
+
+  ${media.tablet} {
+    margin: 32px auto;
+    padding: 0 16px;
+    gap: 20px;
+  }
 
   ${media.mobile} {
-    align-items: center;
     flex-direction: column;
+    margin: 24px auto;
+    padding: 0 12px;
+    gap: 16px;
   }
 `;
 
 export const AnnouncementAndSeminar = styled.section`
-  flex: 45%;
-  width: 90%;
-  margin-right: 100px;
-  font-family: 'Noto Sans KR';
+  flex: 1;
+  width: 100%;
+  max-width: 600px;
   display: flex;
   flex-direction: column;
-
-  ${media.tablet} {
-    margin-right: 40px;
-  }
+  gap: 24px;
 
   ${media.mobile} {
-    flex: 100%;
-    margin-right: 0;
+    max-width: 100%;
+    gap: 16px;
   }
 `;
 
 export const AnnouncementContainer = styled.div`
-  flex: 2;
+  flex: 1;
+  padding: 20px;
+  background-color: white;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 
-  p {
-    font-size: 22px;
+  > p {
+    font-size: 20px;
+    font-weight: 600;
+    margin: 0 0 16px 0;
 
     ${media.mobile} {
-      font-size: 20px;
-      margin-top: 0;
+      font-size: 18px;
+      margin: 0 0 12px 0;
     }
   }
 
   ${media.mobile} {
-    margin-bottom: 40px;
+    padding: 16px;
   }
 `;
 
 export const TabContainer = styled.div`
   display: flex;
+  margin-bottom: 16px;
+
+  ${media.mobile} {
+    margin-bottom: 12px;
+  }
 `;
 
 interface TabButtonProps {
@@ -240,84 +257,104 @@ interface TabButtonProps {
 
 export const TabButton = styled.button<TabButtonProps>`
   flex: 1;
-  padding: 12px 0;
+  padding: 12px;
   background: ${({ isActive }) =>
-    isActive ? `${token.SEJONG_COLORS.CRIMSON_RED}` : '#F1F1F3'};
-  border: ${({ isActive }) =>
-    isActive ? `1px solid ${token.SEJONG_COLORS.CRIMSON_RED}` : 'none'};
+    isActive ? token.SEJONG_COLORS.CRIMSON_RED : '#F1F1F3'};
+  border: none;
   color: ${({ isActive }) => (isActive ? 'white' : '#333')};
-  font-family: 'Noto Sans KR';
-  font-size: 16px;
-  font-weight: 400;
+  font-size: 14px;
+  font-weight: ${({ isActive }) => (isActive ? '600' : '400')};
   cursor: pointer;
-  transition: all 0.3s ease;
+  transition: all 0.2s ease;
 
   &:hover {
     background: ${({ isActive }) =>
-      isActive ? token.SEJONG_COLORS.CRIMSON_RED : '#e9e9eb'};
+      isActive ? token.SEJONG_COLORS.DARK_RED : '#e9e9eb'};
+  }
+
+  ${media.mobile} {
+    padding: 8px;
+    font-size: 13px;
   }
 `;
 
-export const ContentContainer = styled.div``;
+export const ContentContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
 
 export const AnnouncementItem = styled.div`
   display: flex;
   justify-content: space-between;
-  padding: 16px 0;
-  border-bottom: 1px solid #e2e3e5;
+  align-items: center;
+  padding: 12px 8px;
   cursor: pointer;
   transition: background-color 0.2s ease;
+  border-bottom: 1px solid #e2e3e5;
 
   &:hover {
     background-color: #f8f9fa;
   }
 
-  img {
-    margin: 0 8px;
-  }
-
   span {
-    font-size: 15px;
-    font-weight: 400;
-    margin-right: 8px;
+    font-size: 14px;
   }
 
   span:first-of-type {
-    flex-shrink: 1;
-    flex-basis: 100%;
-    max-width: calc(100% - 80px);
+    flex: 1;
+    margin-right: 16px;
     display: -webkit-box;
     -webkit-line-clamp: 1;
     -webkit-box-orient: vertical;
     overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: normal;
+
+    img {
+      margin-right: 8px;
+      vertical-align: middle;
+    }
   }
 
   span:last-of-type {
-    width: 60px;
-    text-align: right;
+    color: #666;
+    white-space: nowrap;
+  }
+
+  ${media.mobile} {
+    padding: 10px 6px;
+
+    span {
+      font-size: 13px;
+    }
+
+    span:first-of-type img {
+      margin-right: 6px;
+      width: 14px;
+      height: 14px;
+    }
   }
 `;
 
 export const SeminarContainer = styled.div`
-  flex: 1;
   display: flex;
-  align-items: flex-end;
+  gap: 16px;
+  height: auto;
+
+  ${media.mobile} {
+    gap: 12px;
+  }
 
   button:first-of-type {
-    height: 200px;
-    flex: 1;
+    flex: 2;
+    min-height: 180px;
     display: flex;
     flex-direction: column;
     justify-content: center;
-    margin-right: 24px;
-    padding: 0 30px;
+    padding: 20px;
     background-color: ${token.SEJONG_COLORS.WARM_GRAY1};
-    border-radius: 0;
     border: none;
+    border-radius: 8px;
     color: white;
-    font-family: 'Noto Sans KR';
     cursor: pointer;
     transition: background-color 0.3s ease;
 
@@ -326,88 +363,58 @@ export const SeminarContainer = styled.div`
     }
 
     p {
-      margin: 16px 0;
-
-      ${media.mobile} {
-        margin: 0 0 0 8px;
-      }
+      margin: 0 0 12px 0;
     }
 
     p:first-of-type {
-      font-size: 22px;
-      margin-bottom: 0;
-
-      ${media.mobile} {
-        font-size: 16px;
-        margin: 10px 0;
-      }
+      font-size: 20px;
+      font-weight: 600;
     }
 
     p:last-of-type {
       font-size: 16px;
-      font-weight: 700;
-
-      ${media.mobile} {
-        font-size: 14px;
-        margin-bottom: 8px;
-      }
+      font-weight: 500;
     }
 
     div {
       font-size: 14px;
-      font-weight: 300;
+      line-height: 1.5;
       text-align: left;
-
-      ${media.mobile} {
-        margin-left: 8px;
-      }
-    }
-
-    img {
-      position: relative;
-      left: 90%;
-      bottom: 15%;
-
-      ${media.mobile} {
-        width: 24px;
-        height: auto;
-        left: 80%;
-        bottom: 80%;
-      }
-    }
-
-    ${media.tablet} {
-      height: 180px;
+      opacity: 0.9;
     }
 
     ${media.mobile} {
-      height: 148px;
-      margin-right: 8px;
-      padding: 0;
-      flex: 1;
-    }
-  }
+      min-height: 160px;
+      padding: 16px;
 
-  ${media.mobile} {
-    margin-bottom: 40px;
+      p:first-of-type {
+        font-size: 18px;
+      }
+
+      p:last-of-type {
+        font-size: 14px;
+      }
+
+      div {
+        font-size: 12px;
+      }
+    }
   }
 `;
 
 export const SeminarRoomReservation = styled(Link)`
-  height: 200px;
   flex: 1;
-  border-radius: 0;
-  border: none;
-  color: white;
-  font-family: 'Noto Sans KR';
-  cursor: pointer;
+  min-height: 180px;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 0 24px;
-  font-size: 22px;
+  padding: 20px;
   background-color: ${token.SEJONG_COLORS.WARM_GRAY1};
+  border-radius: 8px;
+  color: white;
   text-decoration: none;
+  text-align: center;
   transition: background-color 0.3s ease;
 
   &:hover {
@@ -415,53 +422,44 @@ export const SeminarRoomReservation = styled(Link)`
   }
 
   span {
-    margin-right: 20px;
-
-    ${media.mobile} {
-      margin-right: 0;
-      margin-bottom: 8px;
-    }
-  }
-
-  ${media.tablet} {
-    height: 180px;
     font-size: 20px;
+    font-weight: 600;
+    margin-bottom: 12px;
+    line-height: 1.3;
   }
 
   ${media.mobile} {
-    flex-direction: column;
-    flex: 1;
-    padding: 0;
-    height: 148px;
-    font-size: 16px;
-    margin-left: 8px;
+    min-height: 160px;
+    padding: 16px;
+
+    span {
+      font-size: 18px;
+      margin-bottom: 8px;
+    }
+
+    img {
+      width: 24px;
+      height: 24px;
+    }
   }
 `;
 
 export const ShortcutContainer = styled.section`
-  flex: 45%;
   display: grid;
-  justify-items: center;
-  grid-template-rows: repeat(3, auto);
   grid-template-columns: repeat(2, 1fr);
-  gap: 50px 0;
-  padding: 95px 0;
+  gap: 24px;
+  padding: 40px 20px;
   background-color: #e9dfda;
+  border-radius: 8px;
 
   a {
-    width: 100%;
     text-decoration: none;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    font-family: 'Noto Sans KR';
-    font-size: 20px;
-    color: ${token.SEJONG_COLORS.GRAY};
+    color: inherit;
   }
 
   ${media.mobile} {
-    width: 90%;
-    padding: 40px 0;
+    padding: 20px;
+    gap: 16px;
   }
 `;
 
@@ -469,35 +467,33 @@ export const Shortcut = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: fit-content;
-  padding: 10px;
+  justify-content: center;
+  padding: 16px;
+  gap: 12px;
+  text-align: center;
+  color: ${token.SEJONG_COLORS.GRAY};
+  font-size: 16px;
   border-radius: 8px;
-  transition: background-color 0.2s ease;
+  transition: all 0.2s ease;
 
   img {
-    width: 90px;
-    height: auto;
-    margin-bottom: 10px;
-
-    ${media.tablet} {
-      width: 80px;
-    }
-
-    ${media.mobile} {
-      width: 72px;
-    }
+    width: 48px;
+    height: 48px;
   }
 
   &:hover {
-    background-color: rgba(240, 240, 240, 0.3);
-    cursor: pointer;
-  }
-
-  ${media.tablet} {
-    font-size: 20px;
+    background-color: rgba(255, 255, 255, 0.2);
+    transform: translateY(-2px);
   }
 
   ${media.mobile} {
-    font-size: 18px;
+    padding: 12px;
+    gap: 8px;
+    font-size: 14px;
+
+    img {
+      width: 40px;
+      height: 40px;
+    }
   }
 `;

--- a/frontend/src/pages/News/News/News.tsx
+++ b/frontend/src/pages/News/News/News.tsx
@@ -1,0 +1,138 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Eye } from 'lucide-react';
+import moment from 'moment';
+import {
+  Container,
+  NewsGrid,
+  NewsCard,
+  NewsImage,
+  NewsContent,
+  NewsTitle,
+  NewsDate,
+  NewsDescription,
+  NewsFooter,
+  NewsViews,
+  Pagination,
+} from './NewsStyle';
+import { apiEndpoints } from '../../../config/apiConfig';
+
+interface NewsItem {
+  id: number;
+  title: string;
+  content: string;
+  view: number;
+  createDate: string;
+  link: string;
+  image: string;
+}
+
+interface NewsResponse {
+  message: string;
+  page: number;
+  totalPage: number;
+  data: NewsItem[];
+}
+
+const News = () => {
+  const [news, setNews] = useState<NewsItem[]>([]);
+  const [currentPage, setCurrentPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
+  const navigate = useNavigate();
+  const pageSize = 10;
+
+  useEffect(() => {
+    fetchNews();
+  }, [currentPage]);
+
+  const fetchNews = async () => {
+    try {
+      setIsLoading(true);
+      const response = await fetch(
+        apiEndpoints.news.listWithPage(currentPage, pageSize),
+      );
+      if (!response.ok) {
+        throw new Error('Failed to fetch news');
+      }
+      const data: NewsResponse = await response.json();
+      setNews(data.data);
+      setTotalPages(data.totalPage);
+    } catch (error) {
+      console.error('Error fetching news:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleNewsClick = (newsId: number) => {
+    navigate(`/news/${newsId}`);
+  };
+
+  const handlePageChange = (newPage: number) => {
+    if (newPage >= 0 && newPage < totalPages) {
+      setCurrentPage(newPage);
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  };
+
+  const renderPagination = () => {
+    return (
+      <Pagination>
+        <button
+          onClick={() => handlePageChange(currentPage - 1)}
+          disabled={currentPage === 0}
+        >
+          이전
+        </button>
+        {Array.from({ length: totalPages }, (_, i) => (
+          <button
+            key={i}
+            onClick={() => handlePageChange(i)}
+            className={currentPage === i ? 'active' : ''}
+          >
+            {i + 1}
+          </button>
+        ))}
+        <button
+          onClick={() => handlePageChange(currentPage + 1)}
+          disabled={currentPage === totalPages - 1}
+        >
+          다음
+        </button>
+      </Pagination>
+    );
+  };
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <Container>
+      <NewsGrid>
+        {news.map((item) => (
+          <NewsCard key={item.id} onClick={() => handleNewsClick(item.id)}>
+            <NewsImage imageUrl={item.image} />
+            <NewsContent>
+              <NewsTitle>{item.title}</NewsTitle>
+              <NewsDate>
+                {moment(item.createDate).format('YYYY.MM.DD')}
+              </NewsDate>
+              <NewsDescription>{item.content}</NewsDescription>
+              <NewsFooter>
+                <NewsViews>
+                  <Eye size={16} />
+                  {item.view}
+                </NewsViews>
+              </NewsFooter>
+            </NewsContent>
+          </NewsCard>
+        ))}
+      </NewsGrid>
+      {renderPagination()}
+    </Container>
+  );
+};
+
+export default News;

--- a/frontend/src/pages/News/News/News.tsx
+++ b/frontend/src/pages/News/News/News.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Eye } from 'lucide-react';
 import moment from 'moment';
+import { apiEndpoints } from '../../../config/apiConfig';
 import {
   Container,
   NewsGrid,
@@ -14,8 +15,14 @@ import {
   NewsFooter,
   NewsViews,
   Pagination,
+  PageList,
+  PageItem,
+  PageButton,
+  PaginationButton,
+  LoadingSpinner,
+  ErrorMessage,
+  NoResults,
 } from './NewsStyle';
-import { apiEndpoints } from '../../../config/apiConfig';
 
 interface NewsItem {
   id: number;
@@ -39,6 +46,7 @@ const News = () => {
   const [currentPage, setCurrentPage] = useState(0);
   const [totalPages, setTotalPages] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
   const navigate = useNavigate();
   const pageSize = 10;
 
@@ -49,6 +57,7 @@ const News = () => {
   const fetchNews = async () => {
     try {
       setIsLoading(true);
+      setError('');
       const response = await fetch(
         apiEndpoints.news.listWithPage(currentPage, pageSize),
       );
@@ -60,6 +69,7 @@ const News = () => {
       setTotalPages(data.totalPage);
     } catch (error) {
       console.error('Error fetching news:', error);
+      setError('뉴스를 불러오는데 실패했습니다. 잠시 후 다시 시도해주세요.');
     } finally {
       setIsLoading(false);
     }
@@ -77,35 +87,115 @@ const News = () => {
   };
 
   const renderPagination = () => {
-    return (
-      <Pagination>
-        <button
-          onClick={() => handlePageChange(currentPage - 1)}
-          disabled={currentPage === 0}
-        >
-          이전
-        </button>
-        {Array.from({ length: totalPages }, (_, i) => (
-          <button
-            key={i}
-            onClick={() => handlePageChange(i)}
-            className={currentPage === i ? 'active' : ''}
-          >
-            {i + 1}
-          </button>
-        ))}
-        <button
-          onClick={() => handlePageChange(currentPage + 1)}
-          disabled={currentPage === totalPages - 1}
-        >
-          다음
-        </button>
-      </Pagination>
+    const pages = [];
+    const currentPageNum = currentPage + 1;
+
+    // 첫 페이지와 이전 버튼
+    pages.push(
+      <PaginationButton
+        key="first"
+        direction="prev"
+        onClick={() => handlePageChange(0)}
+        disabled={currentPageNum === 1}
+      >
+        ⟪ 처음
+      </PaginationButton>,
+      <PaginationButton
+        key="prev"
+        direction="prev"
+        onClick={() => handlePageChange(currentPage - 1)}
+        disabled={currentPageNum === 1}
+      >
+        ⟨ 이전
+      </PaginationButton>,
     );
+
+    // 페이지 번호 렌더링
+    const pageItems = [];
+    if (totalPages <= 10) {
+      // 10페이지 이하일 경우 모든 페이지 표시
+      for (let i = 1; i <= totalPages; i++) {
+        pageItems.push(
+          <PageItem key={i}>
+            <PageButton
+              onClick={() => handlePageChange(i - 1)}
+              isActive={i === currentPageNum}
+            >
+              {i}
+            </PageButton>
+          </PageItem>,
+        );
+      }
+    } else {
+      // 10페이지 초과시 페이지 범위 계산하여 표시
+      let startPage = Math.max(1, currentPageNum - 4);
+      const endPage = Math.min(totalPages, startPage + 9);
+
+      if (endPage - startPage < 9) {
+        startPage = Math.max(1, endPage - 9);
+      }
+
+      for (let i = startPage; i <= endPage; i++) {
+        pageItems.push(
+          <PageItem key={i}>
+            <PageButton
+              onClick={() => handlePageChange(i - 1)}
+              isActive={i === currentPageNum}
+            >
+              {i}
+            </PageButton>
+          </PageItem>,
+        );
+      }
+    }
+
+    pages.push(<PageList key="pageList">{pageItems}</PageList>);
+
+    // 다음과 마지막 페이지 버튼
+    pages.push(
+      <PaginationButton
+        key="next"
+        direction="next"
+        onClick={() => handlePageChange(currentPage + 1)}
+        disabled={currentPageNum === totalPages}
+      >
+        다음 ⟩
+      </PaginationButton>,
+      <PaginationButton
+        key="last"
+        direction="next"
+        onClick={() => handlePageChange(totalPages - 1)}
+        disabled={currentPageNum === totalPages}
+      >
+        마지막 ⟫
+      </PaginationButton>,
+    );
+
+    return <Pagination>{pages}</Pagination>;
   };
 
   if (isLoading) {
-    return <div>Loading...</div>;
+    return (
+      <Container>
+        <LoadingSpinner>로딩 중...</LoadingSpinner>
+      </Container>
+    );
+  }
+
+  if (error) {
+    return (
+      <Container>
+        <ErrorMessage>{error}</ErrorMessage>
+      </Container>
+    );
+  }
+
+  if (!news.length) {
+    return (
+      <Container>
+        <NoResults>등록된 뉴스가 없습니다.</NoResults>
+      </Container>
+    );
   }
 
   return (
@@ -113,7 +203,12 @@ const News = () => {
       <NewsGrid>
         {news.map((item) => (
           <NewsCard key={item.id} onClick={() => handleNewsClick(item.id)}>
-            <NewsImage imageUrl={item.image} />
+            <NewsImage
+              imageUrl={`https://dibb-bucket.s3.ap-northeast-2.amazonaws.com/news/${item.image}`}
+              onError={(e: React.SyntheticEvent<HTMLDivElement>) => {
+                e.currentTarget.classList.add('error');
+              }}
+            />
             <NewsContent>
               <NewsTitle>{item.title}</NewsTitle>
               <NewsDate>
@@ -130,7 +225,7 @@ const News = () => {
           </NewsCard>
         ))}
       </NewsGrid>
-      {renderPagination()}
+      {totalPages > 1 && renderPagination()}
     </Container>
   );
 };

--- a/frontend/src/pages/News/News/News.tsx
+++ b/frontend/src/pages/News/News/News.tsx
@@ -74,7 +74,6 @@ const News = () => {
       setIsLoading(false);
     }
   };
-
   const handleNewsClick = (newsId: number) => {
     navigate(`/news/${newsId}`);
   };

--- a/frontend/src/pages/News/News/NewsCreate.tsx
+++ b/frontend/src/pages/News/News/NewsCreate.tsx
@@ -1,0 +1,290 @@
+import React, {
+  useState,
+  useRef,
+  useMemo,
+  useCallback,
+  useContext,
+} from 'react';
+import ReactQuill from 'react-quill-new';
+import 'react-quill-new/dist/quill.snow.css';
+import { useNavigate } from 'react-router-dom';
+import { Modal, useModal } from '../../../components/Modal';
+import { AlertTriangle, CheckCircle, PlusCircle } from 'lucide-react';
+import {
+  Container,
+  ContentWrapper,
+  Header,
+  FormSection,
+  FormGroup,
+  Label,
+  Input,
+  QuillWrapper,
+  ButtonGroup,
+  CreateButton,
+  CancelButton,
+  SubmitButton,
+  FileInputLabel,
+  FileInput,
+  FileList,
+  FileItem,
+} from './NewsCreateStyle';
+import { apiEndpoints } from '../../../config/apiConfig';
+import { AuthContext } from '../../../context/AuthContext';
+import axios from 'axios';
+
+interface NewsReqDto {
+  title: string;
+  content: string;
+  createDate: string;
+  link?: string;
+  image?: string;
+}
+
+const NewsCreate: React.FC = () => {
+  const navigate = useNavigate();
+  const [title, setTitle] = useState<string>('');
+  const [content, setContent] = useState<string>('');
+  const [link, setLink] = useState<string>('');
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const quillRef = useRef<ReactQuill>(null);
+  const auth = useContext(AuthContext);
+  const { openModal } = useModal();
+
+  const modules = useMemo(
+    () => ({
+      toolbar: {
+        container: [
+          [{ header: [1, 2, 3, 4, 5, 6, false] }],
+          ['bold', 'italic', 'underline', 'strike'],
+          [{ list: 'ordered' }, { list: 'bullet' }],
+          [{ color: [] }, { background: [] }],
+          ['link'],
+          ['clean'],
+        ],
+      },
+    }),
+    [],
+  );
+
+  const formats = useMemo(
+    () => [
+      'header',
+      'bold',
+      'italic',
+      'underline',
+      'strike',
+      'list',
+      'bullet',
+      'color',
+      'background',
+      'link',
+    ],
+    [],
+  );
+
+  const handleChange = useCallback((value: string) => {
+    setContent(value);
+  }, []);
+
+  const showErrorModal = (title: string, message: string) => {
+    openModal(
+      <>
+        <Modal.Header>
+          <AlertTriangle size={48} color="#E53E3E" />
+          {title}
+        </Modal.Header>
+        <Modal.Content>
+          <p>{message}</p>
+        </Modal.Content>
+        <Modal.Footer>
+          <Modal.CloseButton />
+        </Modal.Footer>
+      </>,
+    );
+  };
+
+  const showSuccessModal = (newsId: number) => {
+    openModal(
+      <>
+        <Modal.Header>
+          <CheckCircle size={48} color="#38A169" />
+          등록 완료
+        </Modal.Header>
+        <Modal.Content>
+          <p>뉴스가 성공적으로 등록되었습니다. (ID: {newsId})</p>
+        </Modal.Content>
+        <Modal.Footer>
+          <Modal.CloseButton onClick={() => navigate('/news')} />
+        </Modal.Footer>
+      </>,
+    );
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!title.trim() || !content.trim()) {
+      showErrorModal('입력 형식 오류', '제목과 내용은 필수 입력값입니다.');
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+
+      const newsReqDto: NewsReqDto = {
+        title: title.trim(),
+        content: content.trim(),
+        createDate: new Date().toISOString().split('T')[0], // YYYY-MM-DD 형식
+        link: link.trim() || undefined,
+      };
+
+      // 이미지 파일이 있는 경우
+      if (imageFile) {
+        const formData = new FormData();
+        formData.append(
+          'newsReqDto',
+          new Blob([JSON.stringify(newsReqDto)], {
+            type: 'application/json',
+          }),
+        );
+        formData.append('news_image', imageFile);
+
+        const response = await axios.post(
+          apiEndpoints.news.create.url,
+          formData,
+          {
+            headers: {
+              'Content-Type': 'multipart/form-data',
+            },
+          },
+        );
+
+        if (response.status === 200) {
+          showSuccessModal(response.data);
+        }
+      } else {
+        // 이미지 파일이 없는 경우
+        const response = await axios.post(
+          apiEndpoints.news.create.url,
+          newsReqDto,
+        );
+
+        if (response.status === 200) {
+          showSuccessModal(response.data);
+        }
+      }
+    } catch (error: any) {
+      console.error('Error creating news:', error);
+      if (error.response?.status === 400) {
+        showErrorModal('입력 오류', error.response.data.message);
+      } else {
+        showErrorModal('등록 실패', '뉴스 등록 중 오류가 발생했습니다');
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const maxSize = 5 * 1024 * 1024; // 5MB
+    if (file.size > maxSize) {
+      showErrorModal(
+        '파일 크기 초과',
+        '이미지 크기는 5MB를 초과할 수 없습니다.',
+      );
+      return;
+    }
+
+    if (!file.type.startsWith('image/')) {
+      showErrorModal('잘못된 파일 형식', '이미지 파일만 업로드할 수 있습니다.');
+      return;
+    }
+
+    setImageFile(file);
+  };
+
+  return (
+    <Container>
+      <ContentWrapper>
+        <Header>
+          <h1>뉴스 작성</h1>
+        </Header>
+
+        <FormSection onSubmit={handleSubmit}>
+          <FormGroup>
+            <Label>제목*</Label>
+            <Input
+              type="text"
+              placeholder="제목을 입력하세요"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              required
+            />
+          </FormGroup>
+
+          <FormGroup>
+            <Label>링크</Label>
+            <Input
+              type="url"
+              placeholder="관련 링크를 입력하세요 (선택사항)"
+              value={link}
+              onChange={(e) => setLink(e.target.value)}
+            />
+          </FormGroup>
+
+          <FormGroup>
+            <Label>대표 이미지</Label>
+            <FileInputLabel>
+              🖼️ 이미지 선택
+              <FileInput
+                type="file"
+                onChange={handleFileChange}
+                accept="image/*"
+              />
+            </FileInputLabel>
+            {imageFile && (
+              <FileList>
+                <FileItem>
+                  {imageFile.name}
+                  <button type="button" onClick={() => setImageFile(null)}>
+                    ×
+                  </button>
+                </FileItem>
+              </FileList>
+            )}
+          </FormGroup>
+
+          <FormGroup>
+            <Label>내용*</Label>
+            <QuillWrapper>
+              <ReactQuill
+                ref={quillRef}
+                theme="snow"
+                value={content}
+                onChange={handleChange}
+                modules={modules}
+                formats={formats}
+                placeholder="내용을 입력하세요"
+              />
+            </QuillWrapper>
+          </FormGroup>
+
+          <ButtonGroup>
+            <CancelButton type="button" onClick={() => navigate('/news')}>
+              취소
+            </CancelButton>
+            <SubmitButton type="submit" disabled={isSubmitting}>
+              {isSubmitting ? '등록 중...' : '뉴스 등록'}
+            </SubmitButton>
+          </ButtonGroup>
+        </FormSection>
+      </ContentWrapper>
+    </Container>
+  );
+};
+
+export default NewsCreate;

--- a/frontend/src/pages/News/News/NewsCreateStyle.ts
+++ b/frontend/src/pages/News/News/NewsCreateStyle.ts
@@ -1,68 +1,66 @@
-// NewsCreateStyle.ts
 import styled from 'styled-components';
 import { media } from '../../../styles/media';
 import { SEJONG_COLORS } from '../../../constants/colors';
 
 export const Container = styled.div`
-  max-width: 1200px;
-  width: 95%;
+  max-width: 780px;
+  width: 100%;
   margin: 0 auto;
-  padding: 40px 20px;
+  padding: 3rem 1.5rem;
 
   ${media.mobile} {
-    padding: 20px 10px;
+    padding: 2rem 1rem;
   }
 `;
 
 export const ContentWrapper = styled.div`
   background: white;
-  border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 `;
 
 export const Header = styled.div`
-  padding: 24px;
-  border-bottom: 1px solid ${SEJONG_COLORS.COOL_GRAY};
+  margin-bottom: 2.5rem;
 
   h1 {
     margin: 0;
-    font-size: 24px;
+    font-size: 2rem;
+    font-weight: 700;
     color: ${SEJONG_COLORS.GRAY};
+    letter-spacing: -0.02em;
   }
 `;
 
 export const FormSection = styled.form`
-  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
 `;
 
 export const FormGroup = styled.div`
-  margin-bottom: 24px;
-
-  &:last-child {
-    margin-bottom: 0;
-  }
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 `;
 
 export const Label = styled.label`
-  display: block;
-  margin-bottom: 8px;
-  font-size: 16px;
-  font-weight: 500;
+  font-size: 0.875rem;
+  font-weight: 600;
   color: ${SEJONG_COLORS.GRAY};
 `;
 
 export const Input = styled.input`
   width: 100%;
-  padding: 12px;
-  border: 1px solid ${SEJONG_COLORS.COOL_GRAY};
-  border-radius: 4px;
-  font-size: 14px;
+  padding: 0.75rem 1rem;
+  border: 1px solid ${SEJONG_COLORS.COOL_GRAY}30;
+  border-radius: 0.5rem;
+  font-size: 1rem;
   color: ${SEJONG_COLORS.GRAY};
-  transition: border-color 0.2s;
+  transition: all 0.2s;
+  background: none;
 
   &:focus {
     outline: none;
     border-color: ${SEJONG_COLORS.CRIMSON_RED};
+    box-shadow: 0 0 0 2px ${SEJONG_COLORS.CRIMSON_RED}10;
   }
 
   &::placeholder {
@@ -71,58 +69,62 @@ export const Input = styled.input`
 `;
 
 export const QuillWrapper = styled.div`
-  .ql-container {
-    min-height: 300px;
-    font-size: 16px;
+  .ql-toolbar {
+    border-color: ${SEJONG_COLORS.COOL_GRAY}30;
+    border-top-left-radius: 0.5rem;
+    border-top-right-radius: 0.5rem;
   }
 
-  .ql-editor {
-    min-height: 300px;
+  .ql-container {
+    border-color: ${SEJONG_COLORS.COOL_GRAY}30;
+    border-bottom-left-radius: 0.5rem;
+    border-bottom-right-radius: 0.5rem;
     font-family: inherit;
   }
 
-  .ql-toolbar {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
-  }
+  .ql-editor {
+    min-height: 360px;
+    font-size: 1rem;
+    line-height: 1.6;
 
-  .ql-container {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    &.ql-blank::before {
+      color: ${SEJONG_COLORS.LIGHT_GRAY};
+      font-style: normal;
+    }
   }
 `;
 
 export const ButtonGroup = styled.div`
   display: flex;
   justify-content: flex-end;
-  gap: 12px;
-  margin-top: 24px;
+  gap: 0.75rem;
+  margin-top: 1rem;
 `;
 
 export const BaseButton = styled.button`
-  padding: 12px 24px;
-  border-radius: 4px;
-  font-size: 14px;
+  padding: 0.75rem 1.5rem;
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
   font-weight: 500;
   cursor: pointer;
   transition: all 0.2s;
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: 0.5rem;
 
   &:disabled {
-    opacity: 0.7;
+    opacity: 0.6;
     cursor: not-allowed;
   }
 `;
 
 export const CancelButton = styled(BaseButton)`
-  border: 1px solid ${SEJONG_COLORS.COOL_GRAY};
-  background: white;
+  border: none;
+  background: ${SEJONG_COLORS.COOL_GRAY}10;
   color: ${SEJONG_COLORS.GRAY};
 
   &:hover:not(:disabled) {
-    background: ${SEJONG_COLORS.IVORY};
+    background: ${SEJONG_COLORS.COOL_GRAY}20;
   }
 `;
 
@@ -136,30 +138,22 @@ export const SubmitButton = styled(BaseButton)`
   }
 `;
 
-export const DeleteButton = styled(BaseButton)`
-  border: 1px solid ${SEJONG_COLORS.RED};
-  background: white;
-  color: ${SEJONG_COLORS.RED};
-
-  &:hover:not(:disabled) {
-    background: ${SEJONG_COLORS.RED};
-    color: white;
-  }
-`;
-
 export const FileInputLabel = styled.label`
   display: inline-flex;
   align-items: center;
-  padding: 8px 16px;
-  border: 1px solid ${SEJONG_COLORS.CRIMSON_RED};
-  border-radius: 4px;
-  color: ${SEJONG_COLORS.CRIMSON_RED};
-  font-size: 14px;
+  gap: 0.5rem;
+  padding: 0.75rem 1.25rem;
+  border: 1px dashed ${SEJONG_COLORS.COOL_GRAY};
+  border-radius: 0.5rem;
+  color: ${SEJONG_COLORS.GRAY};
+  font-size: 0.875rem;
   cursor: pointer;
   transition: all 0.2s;
 
   &:hover {
-    background: ${SEJONG_COLORS.IVORY};
+    border-color: ${SEJONG_COLORS.CRIMSON_RED};
+    color: ${SEJONG_COLORS.CRIMSON_RED};
+    background: ${SEJONG_COLORS.CRIMSON_RED}05;
   }
 `;
 
@@ -170,17 +164,17 @@ export const FileInput = styled.input`
 export const FileList = styled.ul`
   list-style: none;
   padding: 0;
-  margin: 12px 0 0 0;
+  margin: 0.75rem 0 0 0;
 `;
 
 export const FileItem = styled.li`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 8px 12px;
-  background: ${SEJONG_COLORS.IVORY};
-  border-radius: 4px;
-  font-size: 14px;
+  padding: 0.75rem 1rem;
+  background: ${SEJONG_COLORS.COOL_GRAY}10;
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
   color: ${SEJONG_COLORS.GRAY};
 
   button {
@@ -188,9 +182,9 @@ export const FileItem = styled.li`
     background: none;
     color: ${SEJONG_COLORS.LIGHT_GRAY};
     cursor: pointer;
-    padding: 4px 8px;
-    font-size: 16px;
-    transition: color 0.2s;
+    padding: 0.25rem 0.5rem;
+    font-size: 1rem;
+    transition: all 0.2s;
 
     &:hover {
       color: ${SEJONG_COLORS.RED};
@@ -198,28 +192,32 @@ export const FileItem = styled.li`
   }
 `;
 
+export const PreviewImage = styled.img`
+  max-width: 200px;
+  height: auto;
+  margin-top: 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid ${SEJONG_COLORS.COOL_GRAY}30;
+`;
+
 export const CreateButton = styled(BaseButton)`
   border: none;
   background: ${SEJONG_COLORS.CRIMSON_RED};
   color: white;
-  margin-bottom: 20px;
+  margin-bottom: 1.5rem;
 
   &:hover:not(:disabled) {
     background: ${SEJONG_COLORS.DARK_RED};
   }
-`;
 
-export const PreviewImage = styled.img`
-  max-width: 200px;
-  height: auto;
-  margin-top: 8px;
-  border-radius: 4px;
-  border: 1px solid ${SEJONG_COLORS.COOL_GRAY};
+  svg {
+    width: 1.25rem;
+    height: 1.25rem;
+  }
 `;
 
 export const ErrorText = styled.p`
   color: ${SEJONG_COLORS.RED};
-  font-size: 14px;
-  margin-top: 4px;
-  margin-bottom: 0;
+  font-size: 0.875rem;
+  margin: 0.25rem 0 0 0;
 `;

--- a/frontend/src/pages/News/News/NewsCreateStyle.ts
+++ b/frontend/src/pages/News/News/NewsCreateStyle.ts
@@ -1,0 +1,225 @@
+// NewsCreateStyle.ts
+import styled from 'styled-components';
+import { media } from '../../../styles/media';
+import { SEJONG_COLORS } from '../../../constants/colors';
+
+export const Container = styled.div`
+  max-width: 1200px;
+  width: 95%;
+  margin: 0 auto;
+  padding: 40px 20px;
+
+  ${media.mobile} {
+    padding: 20px 10px;
+  }
+`;
+
+export const ContentWrapper = styled.div`
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+`;
+
+export const Header = styled.div`
+  padding: 24px;
+  border-bottom: 1px solid ${SEJONG_COLORS.COOL_GRAY};
+
+  h1 {
+    margin: 0;
+    font-size: 24px;
+    color: ${SEJONG_COLORS.GRAY};
+  }
+`;
+
+export const FormSection = styled.form`
+  padding: 24px;
+`;
+
+export const FormGroup = styled.div`
+  margin-bottom: 24px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+`;
+
+export const Label = styled.label`
+  display: block;
+  margin-bottom: 8px;
+  font-size: 16px;
+  font-weight: 500;
+  color: ${SEJONG_COLORS.GRAY};
+`;
+
+export const Input = styled.input`
+  width: 100%;
+  padding: 12px;
+  border: 1px solid ${SEJONG_COLORS.COOL_GRAY};
+  border-radius: 4px;
+  font-size: 14px;
+  color: ${SEJONG_COLORS.GRAY};
+  transition: border-color 0.2s;
+
+  &:focus {
+    outline: none;
+    border-color: ${SEJONG_COLORS.CRIMSON_RED};
+  }
+
+  &::placeholder {
+    color: ${SEJONG_COLORS.LIGHT_GRAY};
+  }
+`;
+
+export const QuillWrapper = styled.div`
+  .ql-container {
+    min-height: 300px;
+    font-size: 16px;
+  }
+
+  .ql-editor {
+    min-height: 300px;
+    font-family: inherit;
+  }
+
+  .ql-toolbar {
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+  }
+
+  .ql-container {
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+  }
+`;
+
+export const ButtonGroup = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 24px;
+`;
+
+export const BaseButton = styled.button`
+  padding: 12px 24px;
+  border-radius: 4px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  &:disabled {
+    opacity: 0.7;
+    cursor: not-allowed;
+  }
+`;
+
+export const CancelButton = styled(BaseButton)`
+  border: 1px solid ${SEJONG_COLORS.COOL_GRAY};
+  background: white;
+  color: ${SEJONG_COLORS.GRAY};
+
+  &:hover:not(:disabled) {
+    background: ${SEJONG_COLORS.IVORY};
+  }
+`;
+
+export const SubmitButton = styled(BaseButton)`
+  border: none;
+  background: ${SEJONG_COLORS.CRIMSON_RED};
+  color: white;
+
+  &:hover:not(:disabled) {
+    background: ${SEJONG_COLORS.DARK_RED};
+  }
+`;
+
+export const DeleteButton = styled(BaseButton)`
+  border: 1px solid ${SEJONG_COLORS.RED};
+  background: white;
+  color: ${SEJONG_COLORS.RED};
+
+  &:hover:not(:disabled) {
+    background: ${SEJONG_COLORS.RED};
+    color: white;
+  }
+`;
+
+export const FileInputLabel = styled.label`
+  display: inline-flex;
+  align-items: center;
+  padding: 8px 16px;
+  border: 1px solid ${SEJONG_COLORS.CRIMSON_RED};
+  border-radius: 4px;
+  color: ${SEJONG_COLORS.CRIMSON_RED};
+  font-size: 14px;
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &:hover {
+    background: ${SEJONG_COLORS.IVORY};
+  }
+`;
+
+export const FileInput = styled.input`
+  display: none;
+`;
+
+export const FileList = styled.ul`
+  list-style: none;
+  padding: 0;
+  margin: 12px 0 0 0;
+`;
+
+export const FileItem = styled.li`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  background: ${SEJONG_COLORS.IVORY};
+  border-radius: 4px;
+  font-size: 14px;
+  color: ${SEJONG_COLORS.GRAY};
+
+  button {
+    border: none;
+    background: none;
+    color: ${SEJONG_COLORS.LIGHT_GRAY};
+    cursor: pointer;
+    padding: 4px 8px;
+    font-size: 16px;
+    transition: color 0.2s;
+
+    &:hover {
+      color: ${SEJONG_COLORS.RED};
+    }
+  }
+`;
+
+export const CreateButton = styled(BaseButton)`
+  border: none;
+  background: ${SEJONG_COLORS.CRIMSON_RED};
+  color: white;
+  margin-bottom: 20px;
+
+  &:hover:not(:disabled) {
+    background: ${SEJONG_COLORS.DARK_RED};
+  }
+`;
+
+export const PreviewImage = styled.img`
+  max-width: 200px;
+  height: auto;
+  margin-top: 8px;
+  border-radius: 4px;
+  border: 1px solid ${SEJONG_COLORS.COOL_GRAY};
+`;
+
+export const ErrorText = styled.p`
+  color: ${SEJONG_COLORS.RED};
+  font-size: 14px;
+  margin-top: 4px;
+  margin-bottom: 0;
+`;

--- a/frontend/src/pages/News/News/NewsDetail.tsx
+++ b/frontend/src/pages/News/News/NewsDetail.tsx
@@ -1,0 +1,139 @@
+// NewsDetail.tsx
+import React, { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { Eye, ArrowLeft } from 'lucide-react';
+import moment from 'moment';
+import { apiEndpoints } from '../../../config/apiConfig';
+import {
+  Container,
+  BackButton,
+  NewsWrapper,
+  NewsHeader,
+  NewsTitle,
+  NewsMetadata,
+  NewsDate,
+  NewsViews,
+  NewsDivider,
+  NewsImage,
+  NewsContent,
+  NewsLink,
+  LoadingSpinner,
+  ErrorMessage,
+} from './NewsDetailStyle';
+
+interface NewsDetailData {
+  id: number;
+  title: string;
+  content: string;
+  view: number;
+  createDate: string;
+  link: string;
+  image: string;
+}
+
+const NewsDetail = () => {
+  const { newsId } = useParams();
+  const navigate = useNavigate();
+  const [newsData, setNewsData] = useState<NewsDetailData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string>('');
+
+  useEffect(() => {
+    const fetchNewsDetail = async () => {
+      try {
+        setIsLoading(true);
+        if (!newsId) return;
+
+        const response = await fetch(apiEndpoints.news.get(parseInt(newsId)));
+
+        if (!response.ok) {
+          if (response.status === 404) {
+            throw new Error('뉴스를 찾을 수 없습니다.');
+          }
+          throw new Error('뉴스를 불러오는데 실패했습니다.');
+        }
+
+        const data = await response.json();
+        setNewsData(data);
+      } catch (error) {
+        setError(
+          error instanceof Error
+            ? error.message
+            : '알 수 없는 오류가 발생했습니다.',
+        );
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    if (newsId) {
+      fetchNewsDetail();
+    }
+  }, [newsId]);
+
+  const handleBack = () => {
+    navigate(-1);
+  };
+
+  if (isLoading) {
+    return (
+      <Container>
+        <LoadingSpinner>로딩 중...</LoadingSpinner>
+      </Container>
+    );
+  }
+
+  if (error) {
+    return (
+      <Container>
+        <ErrorMessage>{error}</ErrorMessage>
+      </Container>
+    );
+  }
+
+  if (!newsData) {
+    return null;
+  }
+
+  return (
+    <Container>
+      <BackButton onClick={handleBack}>
+        <ArrowLeft size={20} />
+        뒤로 가기
+      </BackButton>
+      <NewsWrapper>
+        <NewsHeader>
+          <NewsTitle>{newsData.title}</NewsTitle>
+          <NewsMetadata>
+            <NewsDate>
+              {moment(newsData.createDate).format('YYYY.MM.DD')}
+            </NewsDate>
+            <NewsViews>
+              <Eye size={16} />
+              {newsData.view}
+            </NewsViews>
+          </NewsMetadata>
+        </NewsHeader>
+        <NewsDivider />
+        {newsData.image && (
+          <NewsImage
+            src={`https://dibb-bucket.s3.ap-northeast-2.amazonaws.com/news/${newsData.image}`}
+            alt={newsData.title}
+          />
+        )}
+        <NewsContent>{newsData.content}</NewsContent>
+        {newsData.link && (
+          <NewsLink
+            href={newsData.link}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            원문 보기
+          </NewsLink>
+        )}
+      </NewsWrapper>
+    </Container>
+  );
+};
+
+export default NewsDetail;

--- a/frontend/src/pages/News/News/NewsDetailStyle.ts
+++ b/frontend/src/pages/News/News/NewsDetailStyle.ts
@@ -1,0 +1,140 @@
+// NewsDetailStyle.ts
+import styled from 'styled-components';
+import { media } from '../../../styles/media';
+import { SEJONG_COLORS } from '../../../constants/colors';
+
+export const Container = styled.div`
+  max-width: 1000px;
+  width: 95%;
+  margin: 0 auto;
+  padding: 40px 20px;
+
+  ${media.mobile} {
+    padding: 20px 10px;
+  }
+`;
+
+export const BackButton = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  border: 1px solid ${SEJONG_COLORS.COOL_GRAY};
+  border-radius: 4px;
+  background: white;
+  color: ${SEJONG_COLORS.GRAY};
+  font-size: 14px;
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &:hover {
+    background: ${SEJONG_COLORS.IVORY};
+    color: ${SEJONG_COLORS.CRIMSON_RED};
+  }
+`;
+
+export const NewsWrapper = styled.article`
+  margin-top: 24px;
+  background: white;
+  border: 1px solid ${SEJONG_COLORS.COOL_GRAY};
+  border-radius: 8px;
+  overflow: hidden;
+`;
+
+export const NewsHeader = styled.header`
+  padding: 24px;
+`;
+
+export const NewsTitle = styled.h1`
+  margin: 0;
+  font-size: 24px;
+  font-weight: 600;
+  color: ${SEJONG_COLORS.GRAY};
+  line-height: 1.4;
+
+  ${media.mobile} {
+    font-size: 20px;
+  }
+`;
+
+export const NewsMetadata = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-top: 16px;
+`;
+
+export const NewsDate = styled.span`
+  font-size: 14px;
+  color: ${SEJONG_COLORS.LIGHT_GRAY};
+`;
+
+export const NewsViews = styled.span`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 14px;
+  color: ${SEJONG_COLORS.LIGHT_GRAY};
+
+  svg {
+    color: ${SEJONG_COLORS.WARM_GRAY1};
+  }
+`;
+
+export const NewsDivider = styled.hr`
+  margin: 0;
+  border: none;
+  border-top: 1px solid ${SEJONG_COLORS.COOL_GRAY};
+`;
+
+export const NewsImage = styled.img`
+  display: block;
+  width: 100%;
+  max-height: 500px;
+  object-fit: cover;
+  margin: 0 auto;
+`;
+
+export const NewsContent = styled.div`
+  padding: 24px;
+  font-size: 16px;
+  line-height: 1.8;
+  color: ${SEJONG_COLORS.GRAY};
+  white-space: pre-wrap;
+
+  ${media.mobile} {
+    font-size: 15px;
+  }
+`;
+
+export const NewsLink = styled.a`
+  display: inline-block;
+  margin: 0 24px 24px;
+  padding: 8px 16px;
+  border: 1px solid ${SEJONG_COLORS.CRIMSON_RED};
+  border-radius: 4px;
+  color: ${SEJONG_COLORS.CRIMSON_RED};
+  text-decoration: none;
+  font-size: 14px;
+  transition: all 0.2s;
+
+  &:hover {
+    background: ${SEJONG_COLORS.CRIMSON_RED};
+    color: white;
+  }
+`;
+
+export const LoadingSpinner = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 200px;
+  color: ${SEJONG_COLORS.CRIMSON_RED};
+`;
+
+export const ErrorMessage = styled.div`
+  text-align: center;
+  padding: 40px;
+  color: ${SEJONG_COLORS.CRIMSON_RED};
+  font-size: 16px;
+`;

--- a/frontend/src/pages/News/News/NewsDetailStyle.ts
+++ b/frontend/src/pages/News/News/NewsDetailStyle.ts
@@ -1,126 +1,133 @@
-// NewsDetailStyle.ts
 import styled from 'styled-components';
 import { media } from '../../../styles/media';
 import { SEJONG_COLORS } from '../../../constants/colors';
 
 export const Container = styled.div`
-  max-width: 1000px;
-  width: 95%;
+  max-width: 780px;
+  width: 100%;
   margin: 0 auto;
-  padding: 40px 20px;
+  padding: 3rem 1.5rem;
 
   ${media.mobile} {
-    padding: 20px 10px;
+    padding: 2rem 1rem;
   }
 `;
 
 export const BackButton = styled.button`
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 16px;
-  border: 1px solid ${SEJONG_COLORS.COOL_GRAY};
-  border-radius: 4px;
-  background: white;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  border: none;
+  background: none;
   color: ${SEJONG_COLORS.GRAY};
-  font-size: 14px;
+  font-size: 0.875rem;
   cursor: pointer;
   transition: all 0.2s;
 
   &:hover {
-    background: ${SEJONG_COLORS.IVORY};
     color: ${SEJONG_COLORS.CRIMSON_RED};
+    transform: translateX(-4px);
+  }
+
+  svg {
+    width: 1.25rem;
+    height: 1.25rem;
   }
 `;
 
 export const NewsWrapper = styled.article`
-  margin-top: 24px;
+  margin-top: 2rem;
   background: white;
-  border: 1px solid ${SEJONG_COLORS.COOL_GRAY};
-  border-radius: 8px;
-  overflow: hidden;
 `;
 
 export const NewsHeader = styled.header`
-  padding: 24px;
+  margin-bottom: 2rem;
 `;
 
 export const NewsTitle = styled.h1`
   margin: 0;
-  font-size: 24px;
-  font-weight: 600;
+  font-size: 2rem;
+  font-weight: 700;
   color: ${SEJONG_COLORS.GRAY};
   line-height: 1.4;
+  letter-spacing: -0.02em;
 
   ${media.mobile} {
-    font-size: 20px;
+    font-size: 1.5rem;
   }
 `;
 
 export const NewsMetadata = styled.div`
   display: flex;
   align-items: center;
-  gap: 16px;
-  margin-top: 16px;
+  gap: 1rem;
+  margin-top: 1rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid ${SEJONG_COLORS.COOL_GRAY}15;
 `;
 
 export const NewsDate = styled.span`
-  font-size: 14px;
+  font-size: 0.875rem;
   color: ${SEJONG_COLORS.LIGHT_GRAY};
 `;
 
 export const NewsViews = styled.span`
   display: flex;
   align-items: center;
-  gap: 4px;
-  font-size: 14px;
+  gap: 0.25rem;
+  font-size: 0.875rem;
   color: ${SEJONG_COLORS.LIGHT_GRAY};
 
   svg {
+    width: 1rem;
+    height: 1rem;
     color: ${SEJONG_COLORS.WARM_GRAY1};
   }
 `;
 
 export const NewsDivider = styled.hr`
-  margin: 0;
-  border: none;
-  border-top: 1px solid ${SEJONG_COLORS.COOL_GRAY};
+  display: none;
 `;
 
 export const NewsImage = styled.img`
   display: block;
   width: 100%;
-  max-height: 500px;
+  max-height: 480px;
   object-fit: cover;
-  margin: 0 auto;
+  margin: 2rem 0;
+  border-radius: 0.5rem;
 `;
 
 export const NewsContent = styled.div`
-  padding: 24px;
-  font-size: 16px;
+  font-size: 1rem;
   line-height: 1.8;
   color: ${SEJONG_COLORS.GRAY};
   white-space: pre-wrap;
+  letter-spacing: -0.01em;
 
   ${media.mobile} {
-    font-size: 15px;
+    font-size: 0.9375rem;
   }
 `;
 
 export const NewsLink = styled.a`
-  display: inline-block;
-  margin: 0 24px 24px;
-  padding: 8px 16px;
-  border: 1px solid ${SEJONG_COLORS.CRIMSON_RED};
-  border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  margin-top: 2rem;
+  padding: 0.75rem 1.25rem;
+  border: none;
+  border-radius: 0.375rem;
+  background-color: ${SEJONG_COLORS.CRIMSON_RED}10;
   color: ${SEJONG_COLORS.CRIMSON_RED};
   text-decoration: none;
-  font-size: 14px;
+  font-size: 0.875rem;
+  font-weight: 500;
   transition: all 0.2s;
 
   &:hover {
-    background: ${SEJONG_COLORS.CRIMSON_RED};
-    color: white;
+    background-color: ${SEJONG_COLORS.CRIMSON_RED}20;
+    transform: translateY(-2px);
   }
 `;
 
@@ -128,13 +135,16 @@ export const LoadingSpinner = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  min-height: 200px;
+  min-height: 50vh;
   color: ${SEJONG_COLORS.CRIMSON_RED};
+  font-size: 0.875rem;
 `;
 
 export const ErrorMessage = styled.div`
   text-align: center;
-  padding: 40px;
+  padding: 3rem 2rem;
   color: ${SEJONG_COLORS.CRIMSON_RED};
-  font-size: 16px;
+  font-size: 0.875rem;
+  background-color: ${SEJONG_COLORS.CRIMSON_RED}10;
+  border-radius: 0.5rem;
 `;

--- a/frontend/src/pages/News/News/NewsEdit.tsx
+++ b/frontend/src/pages/News/News/NewsEdit.tsx
@@ -1,0 +1,349 @@
+import React, {
+  useState,
+  useRef,
+  useMemo,
+  useCallback,
+  useContext,
+  useEffect,
+} from 'react';
+import ReactQuill from 'react-quill-new';
+import 'react-quill-new/dist/quill.snow.css';
+import { useNavigate, useParams } from 'react-router-dom';
+import { Modal, useModal } from '../../../components/Modal';
+import { AlertTriangle, CheckCircle } from 'lucide-react';
+import {
+  Container,
+  ContentWrapper,
+  Header,
+  FormSection,
+  FormGroup,
+  Label,
+  Input,
+  QuillWrapper,
+  ButtonGroup,
+  CancelButton,
+  SubmitButton,
+  FileInputLabel,
+  FileInput,
+  FileList,
+  FileItem,
+} from './NewsCreateStyle'; // 기존 스타일 재사용
+import { apiEndpoints } from '../../../config/apiConfig';
+import { AuthContext } from '../../../context/AuthContext';
+import axios from 'axios';
+
+interface NewsData {
+  id: number;
+  title: string;
+  content: string;
+  view: number;
+  createDate: string;
+  link: string;
+  image: string;
+}
+
+const NewsEdit: React.FC = () => {
+  const { newsId } = useParams();
+  const navigate = useNavigate();
+  const [title, setTitle] = useState<string>('');
+  const [content, setContent] = useState<string>('');
+  const [link, setLink] = useState<string>('');
+  const [currentImage, setCurrentImage] = useState<string>('');
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const quillRef = useRef<ReactQuill>(null);
+  const auth = useContext(AuthContext);
+  const { openModal } = useModal();
+
+  useEffect(() => {
+    const fetchNewsData = async () => {
+      try {
+        if (!newsId) return;
+
+        const response = await fetch(apiEndpoints.news.get(newsId));
+        if (!response.ok) {
+          if (response.status === 404) {
+            throw new Error('뉴스를 찾을 수 없습니다.');
+          }
+          throw new Error('뉴스를 불러오는데 실패했습니다.');
+        }
+
+        const data: NewsData = await response.json();
+        setTitle(data.title);
+        setContent(data.content);
+        setLink(data.link || '');
+        setCurrentImage(data.image || '');
+      } catch (error) {
+        console.error('Error fetching news:', error);
+        showErrorModal(
+          '데이터 로딩 실패',
+          '뉴스 데이터를 불러오는데 실패했습니다.',
+        );
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchNewsData();
+  }, [newsId]);
+
+  const modules = useMemo(
+    () => ({
+      toolbar: {
+        container: [
+          [{ header: [1, 2, 3, 4, 5, 6, false] }],
+          ['bold', 'italic', 'underline', 'strike'],
+          [{ list: 'ordered' }, { list: 'bullet' }],
+          [{ color: [] }, { background: [] }],
+          ['link'],
+          ['clean'],
+        ],
+      },
+    }),
+    [],
+  );
+
+  const formats = useMemo(
+    () => [
+      'header',
+      'bold',
+      'italic',
+      'underline',
+      'strike',
+      'list',
+      'bullet',
+      'color',
+      'background',
+      'link',
+    ],
+    [],
+  );
+
+  const handleChange = useCallback((value: string) => {
+    setContent(value);
+  }, []);
+
+  const showErrorModal = (title: string, message: string) => {
+    openModal(
+      <>
+        <Modal.Header>
+          <AlertTriangle size={48} color="#E53E3E" />
+          {title}
+        </Modal.Header>
+        <Modal.Content>
+          <p>{message}</p>
+        </Modal.Content>
+        <Modal.Footer>
+          <Modal.CloseButton />
+        </Modal.Footer>
+      </>,
+    );
+  };
+
+  const showSuccessModal = () => {
+    openModal(
+      <>
+        <Modal.Header>
+          <CheckCircle size={48} color="#38A169" />
+          수정 완료
+        </Modal.Header>
+        <Modal.Content>
+          <p>뉴스가 성공적으로 수정되었습니다.</p>
+        </Modal.Content>
+        <Modal.Footer>
+          <Modal.CloseButton onClick={() => navigate('/news')} />
+        </Modal.Footer>
+      </>,
+    );
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!title.trim() || !content.trim()) {
+      showErrorModal('입력 형식 오류', '제목과 내용은 필수 입력값입니다.');
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+
+      const newsReqDto = {
+        title: title.trim(),
+        content: content.trim(),
+        createDate: new Date().toISOString().split('T')[0],
+        link: link.trim() || undefined,
+        image: currentImage,
+      };
+
+      if (!newsId) {
+        throw new Error('뉴스 ID가 없습니다.');
+      }
+
+      if (imageFile) {
+        const formData = new FormData();
+        formData.append(
+          'newsReqDto',
+          new Blob([JSON.stringify(newsReqDto)], {
+            type: 'application/json',
+          }),
+        );
+        formData.append('news_image', imageFile);
+
+        const response = await axios.put(
+          apiEndpoints.news.update.url(newsId),
+          formData,
+          {
+            headers: {
+              'Content-Type': 'multipart/form-data',
+            },
+          },
+        );
+
+        if (response.status === 200) {
+          showSuccessModal();
+        }
+      } else {
+        const response = await axios.post(
+          apiEndpoints.news.update.url(newsId),
+          newsReqDto,
+        );
+
+        if (response.status === 200) {
+          showSuccessModal();
+        }
+      }
+    } catch (error: any) {
+      console.error('Error updating news:', error);
+      if (error.response?.status === 404) {
+        showErrorModal('뉴스 없음', '해당 뉴스를 찾을 수 없습니다.');
+      } else if (error.response?.status === 400) {
+        showErrorModal('입력 오류', error.response.data.message);
+      } else {
+        showErrorModal('수정 실패', '뉴스 수정 중 오류가 발생했습니다');
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const maxSize = 5 * 1024 * 1024; // 5MB
+    if (file.size > maxSize) {
+      showErrorModal(
+        '파일 크기 초과',
+        '이미지 크기는 5MB를 초과할 수 없습니다.',
+      );
+      return;
+    }
+
+    if (!file.type.startsWith('image/')) {
+      showErrorModal('잘못된 파일 형식', '이미지 파일만 업로드할 수 있습니다.');
+      return;
+    }
+
+    setImageFile(file);
+  };
+
+  if (isLoading) {
+    return (
+      <Container>
+        <div>로딩 중...</div>
+      </Container>
+    );
+  }
+
+  return (
+    <Container>
+      <ContentWrapper>
+        <Header>
+          <h1>뉴스 수정</h1>
+        </Header>
+
+        <FormSection onSubmit={handleSubmit}>
+          <FormGroup>
+            <Label>제목*</Label>
+            <Input
+              type="text"
+              placeholder="제목을 입력하세요"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              required
+            />
+          </FormGroup>
+
+          <FormGroup>
+            <Label>링크</Label>
+            <Input
+              type="url"
+              placeholder="관련 링크를 입력하세요 (선택사항)"
+              value={link}
+              onChange={(e) => setLink(e.target.value)}
+            />
+          </FormGroup>
+
+          <FormGroup>
+            <Label>대표 이미지</Label>
+            {currentImage && (
+              <div>
+                <img
+                  src={`https://dibb-bucket.s3.ap-northeast-2.amazonaws.com/news/${currentImage}`}
+                  alt="현재 이미지"
+                  style={{ maxWidth: '200px', marginBottom: '10px' }}
+                />
+              </div>
+            )}
+            <FileInputLabel>
+              🖼️ 새 이미지 선택
+              <FileInput
+                type="file"
+                onChange={handleFileChange}
+                accept="image/*"
+              />
+            </FileInputLabel>
+            {imageFile && (
+              <FileList>
+                <FileItem>
+                  {imageFile.name}
+                  <button type="button" onClick={() => setImageFile(null)}>
+                    ×
+                  </button>
+                </FileItem>
+              </FileList>
+            )}
+          </FormGroup>
+
+          <FormGroup>
+            <Label>내용*</Label>
+            <QuillWrapper>
+              <ReactQuill
+                ref={quillRef}
+                theme="snow"
+                value={content}
+                onChange={handleChange}
+                modules={modules}
+                formats={formats}
+                placeholder="내용을 입력하세요"
+              />
+            </QuillWrapper>
+          </FormGroup>
+
+          <ButtonGroup>
+            <CancelButton type="button" onClick={() => navigate('/news')}>
+              취소
+            </CancelButton>
+            <SubmitButton type="submit" disabled={isSubmitting}>
+              {isSubmitting ? '수정 중...' : '뉴스 수정'}
+            </SubmitButton>
+          </ButtonGroup>
+        </FormSection>
+      </ContentWrapper>
+    </Container>
+  );
+};
+
+export default NewsEdit;

--- a/frontend/src/pages/News/News/NewsStyle.ts
+++ b/frontend/src/pages/News/News/NewsStyle.ts
@@ -15,45 +15,47 @@ export const Container = styled.div`
 `;
 
 export const NewsGrid = styled.div`
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(600px, 1fr));
-  gap: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
   margin-top: 1.75rem;
-
-  ${media.mobile} {
-    grid-template-columns: 1fr;
-    gap: 1.25rem;
-  }
 `;
 
 export const NewsCard = styled.div`
   display: flex;
-  border: 1px solid ${SEJONG_COLORS.COOL_GRAY};
-  border-radius: 8px;
-  overflow: hidden;
-  background-color: white;
+  gap: 2rem;
+  padding: 1.5rem 0;
   cursor: pointer;
   transition: all 0.2s ease-in-out;
+  border-bottom: 1px solid ${SEJONG_COLORS.COOL_GRAY}15;
+
+  &:first-child {
+    padding-top: 0;
+  }
+
+  &:last-child {
+    padding-bottom: 0;
+    border-bottom: none;
+  }
 
   &:hover {
-    transform: translateY(-4px);
-    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
+    opacity: 0.8;
+  }
+
+  ${media.mobile} {
+    gap: 1rem;
+    padding: 1rem 0;
   }
 `;
 
 export const NewsImage = styled.div<{ imageUrl: string }>`
-  width: 280px;
-  min-width: 280px;
-  height: 200px;
+  width: 200px;
+  min-width: 200px;
+  height: 150px;
   background-image: url(${(props) => props.imageUrl});
   background-size: cover;
   background-position: center;
   background-color: ${SEJONG_COLORS.COOL_GRAY};
-  transition: transform 0.3s ease;
-
-  ${NewsCard}:hover & {
-    transform: scale(1.05);
-  }
 
   &.error {
     background-image: none;
@@ -70,15 +72,15 @@ export const NewsImage = styled.div<{ imageUrl: string }>`
   ${media.mobile} {
     width: 120px;
     min-width: 120px;
-    height: 120px;
+    height: 90px;
   }
 `;
 
 export const NewsContent = styled.div`
   flex: 1;
-  padding: 1.5rem;
   display: flex;
   flex-direction: column;
+  gap: 0.75rem;
 `;
 
 export const NewsTitle = styled.h3`
@@ -91,21 +93,20 @@ export const NewsTitle = styled.h3`
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
-  min-height: 2.8rem;
 
   ${media.mobile} {
-    font-size: 1.25rem;
+    font-size: 1.125rem;
   }
 `;
 
 export const NewsDate = styled.p`
-  margin: 1rem 0 0 0;
-  font-size: 0.95rem;
+  margin: 0;
+  font-size: 0.875rem;
   color: ${SEJONG_COLORS.LIGHT_GRAY};
 `;
 
 export const NewsDescription = styled.p`
-  margin: 0.875rem 0;
+  margin: 0;
   font-size: 1rem;
   color: ${SEJONG_COLORS.WARM_GRAY2};
   line-height: 1.6;
@@ -113,40 +114,34 @@ export const NewsDescription = styled.p`
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
-  min-height: 3.2em;
 
   ${media.mobile} {
-    font-size: 0.95rem;
+    font-size: 0.875rem;
+    -webkit-line-clamp: 3;
   }
 `;
 
 export const NewsFooter = styled.div`
   display: flex;
   align-items: center;
-  margin-top: 1.5rem;
-  padding-top: 1.25rem;
-  border-top: 1px solid ${SEJONG_COLORS.COOL_GRAY}20;
-
-  ${media.mobile} {
-    margin-top: 1.25rem;
-    padding-top: 1.25rem;
-  }
+  margin-top: auto;
 `;
 
 export const NewsViews = styled.span`
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  font-size: 0.95rem;
+  font-size: 0.875rem;
   color: ${SEJONG_COLORS.LIGHT_GRAY};
 
   svg {
-    width: 1.25rem;
-    height: 1.25rem;
+    width: 1rem;
+    height: 1rem;
     color: ${SEJONG_COLORS.WARM_GRAY1};
   }
 `;
 
+// 관리자 관련 스타일
 export const AdminButtonGroup = styled.div`
   display: flex;
   justify-content: flex-end;
@@ -173,12 +168,6 @@ export const CreateButton = styled.button`
 
   &:hover {
     background-color: ${SEJONG_COLORS.DARK_RED};
-    box-shadow: 0 2px 4px rgba(139, 0, 0, 0.2);
-  }
-
-  &:active {
-    transform: translateY(1px);
-    box-shadow: none;
   }
 
   svg {
@@ -196,10 +185,6 @@ export const AdminActions = styled.div`
   display: flex;
   gap: 0.5rem;
   margin-left: auto;
-
-  ${media.mobile} {
-    gap: 0.375rem;
-  }
 `;
 
 export const ActionButton = styled.button`
@@ -282,7 +267,7 @@ export const PageButton = styled.button<{ isActive?: boolean }>`
 
   &:hover:not(:disabled) {
     background: ${(props) =>
-      props.isActive ? '#8b0000' : SEJONG_COLORS.COOL_GRAY}10;
+      props.isActive ? '#8b0000' : `${SEJONG_COLORS.COOL_GRAY}10`};
     border-color: ${(props) =>
       props.isActive ? '#8b0000' : SEJONG_COLORS.CRIMSON_RED};
   }
@@ -290,10 +275,6 @@ export const PageButton = styled.button<{ isActive?: boolean }>`
   &:disabled {
     cursor: not-allowed;
     opacity: 0.5;
-  }
-
-  &:active:not(:disabled) {
-    transform: translateY(1px);
   }
 
   ${media.mobile} {
@@ -328,10 +309,6 @@ export const PaginationButton = styled.button<{
     background: ${SEJONG_COLORS.COOL_GRAY}10;
     border-color: ${(props) =>
       props.disabled ? SEJONG_COLORS.COOL_GRAY : '#8b0000'};
-  }
-
-  &:active:not(:disabled) {
-    transform: translateY(1px);
   }
 
   ${media.mobile} {

--- a/frontend/src/pages/News/News/NewsStyle.ts
+++ b/frontend/src/pages/News/News/NewsStyle.ts
@@ -129,15 +129,6 @@ export const NewsDescription = styled.p`
   }
 `;
 
-export const NewsFooter = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-top: 12px;
-  padding-top: 12px;
-  border-top: 1px solid ${SEJONG_COLORS.COOL_GRAY};
-`;
-
 export const NewsViews = styled.span`
   display: flex;
   align-items: center;
@@ -279,4 +270,103 @@ export const NoResults = styled.div`
   padding: 40px;
   color: ${SEJONG_COLORS.GRAY};
   font-size: 16px;
+`;
+
+export const AdminButtonGroup = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 20px;
+
+  ${media.mobile} {
+    margin-bottom: 16px;
+  }
+`;
+
+export const CreateButton = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  background-color: ${SEJONG_COLORS.CRIMSON_RED};
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-size: 14px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background-color: ${SEJONG_COLORS.DARK_RED};
+  }
+
+  svg {
+    width: 20px;
+    height: 20px;
+  }
+
+  ${media.mobile} {
+    padding: 6px 12px;
+    font-size: 13px;
+  }
+`;
+
+export const ActionButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px;
+  border: 1px solid ${SEJONG_COLORS.COOL_GRAY};
+  border-radius: 4px;
+  background: white;
+  color: ${SEJONG_COLORS.GRAY};
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background: ${SEJONG_COLORS.IVORY};
+    border-color: ${SEJONG_COLORS.CRIMSON_RED};
+    color: ${SEJONG_COLORS.CRIMSON_RED};
+  }
+
+  &:last-child:hover {
+    border-color: ${SEJONG_COLORS.RED};
+    color: ${SEJONG_COLORS.RED};
+  }
+
+  svg {
+    width: 16px;
+    height: 16px;
+  }
+
+  ${media.mobile} {
+    padding: 4px;
+
+    svg {
+      width: 14px;
+      height: 14px;
+    }
+  }
+`;
+
+export const AdminActions = styled.div`
+  display: flex;
+  gap: 8px;
+  margin-left: auto;
+
+  ${media.mobile} {
+    gap: 6px;
+  }
+`;
+
+export const NewsFooter = styled.div`
+  display: flex;
+  align-items: center;
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid ${SEJONG_COLORS.COOL_GRAY};
+
+  ${media.mobile} {
+    margin-top: 10px;
+    padding-top: 10px;
+  }
 `;

--- a/frontend/src/pages/News/News/NewsStyle.ts
+++ b/frontend/src/pages/News/News/NewsStyle.ts
@@ -39,6 +39,14 @@ export const NewsCard = styled.div`
   }
 `;
 
+export const NewsImageWrapper = styled.div`
+  width: 100%;
+  height: 200px;
+  overflow: hidden;
+  background-color: ${SEJONG_COLORS.COOL_GRAY};
+  position: relative;
+`;
+
 export const NewsImage = styled.div<{ imageUrl: string }>`
   width: 100%;
   height: 200px;
@@ -46,6 +54,37 @@ export const NewsImage = styled.div<{ imageUrl: string }>`
   background-size: cover;
   background-position: center;
   background-color: ${SEJONG_COLORS.COOL_GRAY};
+  transition: transform 0.3s ease;
+
+  ${NewsCard}:hover & {
+    transform: scale(1.05);
+  }
+
+  &.error {
+    background-image: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: ${SEJONG_COLORS.GRAY};
+    font-size: 14px;
+    &::after {
+      content: '이미지를 불러올 수 없습니다';
+    }
+  }
+`;
+
+export const ImageFallback = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: ${SEJONG_COLORS.COOL_GRAY};
+  color: ${SEJONG_COLORS.GRAY};
+  font-size: 14px;
 `;
 
 export const NewsContent = styled.div`

--- a/frontend/src/pages/News/News/NewsStyle.ts
+++ b/frontend/src/pages/News/News/NewsStyle.ts
@@ -1,0 +1,243 @@
+import styled from 'styled-components';
+import { media } from '../../../styles/media';
+import { SEJONG_COLORS } from '../../../constants/colors';
+
+export const Container = styled.div`
+  max-width: 1400px;
+  width: 95%;
+  margin: 0 auto;
+  padding: 40px 20px;
+
+  ${media.mobile} {
+    padding: 20px 10px;
+  }
+`;
+
+export const NewsGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 24px;
+  margin-top: 20px;
+
+  ${media.mobile} {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+`;
+
+export const NewsCard = styled.div`
+  border: 1px solid ${SEJONG_COLORS.COOL_GRAY};
+  border-radius: 8px;
+  overflow: hidden;
+  background-color: white;
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+
+  &:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  }
+`;
+
+export const NewsImage = styled.div<{ imageUrl: string }>`
+  width: 100%;
+  height: 200px;
+  background-image: url(${(props) => props.imageUrl});
+  background-size: cover;
+  background-position: center;
+  background-color: ${SEJONG_COLORS.COOL_GRAY};
+`;
+
+export const NewsContent = styled.div`
+  padding: 20px;
+`;
+
+export const NewsTitle = styled.h3`
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: ${SEJONG_COLORS.GRAY};
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+
+  ${media.mobile} {
+    font-size: 16px;
+  }
+`;
+
+export const NewsDate = styled.p`
+  margin: 8px 0 0 0;
+  font-size: 14px;
+  color: ${SEJONG_COLORS.LIGHT_GRAY};
+`;
+
+export const NewsDescription = styled.p`
+  margin: 12px 0;
+  font-size: 14px;
+  color: ${SEJONG_COLORS.WARM_GRAY2};
+  line-height: 1.6;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  height: 4.8em;
+
+  ${media.mobile} {
+    font-size: 13px;
+  }
+`;
+
+export const NewsFooter = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid ${SEJONG_COLORS.COOL_GRAY};
+`;
+
+export const NewsViews = styled.span`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 14px;
+  color: ${SEJONG_COLORS.LIGHT_GRAY};
+
+  svg {
+    width: 16px;
+    height: 16px;
+    color: ${SEJONG_COLORS.WARM_GRAY1};
+  }
+`;
+
+export const PaginationButton = styled.button<{
+  direction?: 'prev' | 'next';
+  disabled?: boolean;
+}>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 12px;
+  min-width: 80px;
+  height: 36px;
+  border: 1px solid
+    ${(props) =>
+      props.disabled ? SEJONG_COLORS.COOL_GRAY : SEJONG_COLORS.CRIMSON_RED};
+  background-color: white;
+  color: ${(props) =>
+    props.disabled ? SEJONG_COLORS.LIGHT_GRAY : SEJONG_COLORS.CRIMSON_RED};
+  font-size: 14px;
+  border-radius: 4px;
+  cursor: ${(props) => (props.disabled ? 'not-allowed' : 'pointer')};
+  transition: all 0.2s;
+
+  &:hover:not(:disabled) {
+    background-color: ${SEJONG_COLORS.IVORY};
+  }
+
+  svg {
+    width: 16px;
+    height: 16px;
+    margin: ${(props) =>
+      props.direction === 'prev' ? '0 4px 0 0' : '0 0 0 4px'};
+  }
+
+  ${media.mobile} {
+    min-width: 60px;
+    padding: 6px 8px;
+    font-size: 13px;
+  }
+`;
+
+export const PageEllipsis = styled.span`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  color: ${SEJONG_COLORS.GRAY};
+
+  ${media.mobile} {
+    width: 32px;
+    height: 32px;
+  }
+`;
+
+export const Pagination = styled.nav`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 40px;
+`;
+
+export const PageList = styled.ul`
+  display: flex;
+  list-style: none;
+  padding: 0;
+  gap: 8px;
+`;
+
+export const PageItem = styled.li`
+  margin: 0;
+  padding: 0;
+`;
+
+export const PageButton = styled.button<{ isActive?: boolean }>`
+  min-width: 36px;
+  height: 36px;
+  padding: 0 12px;
+  border: 1px solid
+    ${(props) =>
+      props.isActive ? SEJONG_COLORS.CRIMSON_RED : SEJONG_COLORS.COOL_GRAY};
+  background: ${(props) =>
+    props.isActive ? SEJONG_COLORS.CRIMSON_RED : 'white'};
+  color: ${(props) => (props.isActive ? 'white' : SEJONG_COLORS.GRAY)};
+  font-size: 14px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &:hover {
+    background: ${(props) =>
+      props.isActive ? SEJONG_COLORS.CRIMSON_RED : SEJONG_COLORS.IVORY};
+  }
+
+  &:disabled {
+    background: ${SEJONG_COLORS.COOL_GRAY};
+    border-color: ${SEJONG_COLORS.COOL_GRAY};
+    color: ${SEJONG_COLORS.LIGHT_GRAY};
+    cursor: not-allowed;
+  }
+
+  ${media.mobile} {
+    min-width: 32px;
+    height: 32px;
+    padding: 0 8px;
+    font-size: 13px;
+  }
+`;
+
+export const LoadingSpinner = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 200px;
+  color: ${SEJONG_COLORS.CRIMSON_RED};
+`;
+
+export const ErrorMessage = styled.div`
+  text-align: center;
+  padding: 40px;
+  color: ${SEJONG_COLORS.CRIMSON_RED};
+  font-size: 16px;
+`;
+
+export const NoResults = styled.div`
+  text-align: center;
+  padding: 40px;
+  color: ${SEJONG_COLORS.GRAY};
+  font-size: 16px;
+`;

--- a/frontend/src/pages/News/News/NewsStyle.ts
+++ b/frontend/src/pages/News/News/NewsStyle.ts
@@ -3,29 +3,31 @@ import { media } from '../../../styles/media';
 import { SEJONG_COLORS } from '../../../constants/colors';
 
 export const Container = styled.div`
-  max-width: 1400px;
-  width: 95%;
+  max-width: 90%;
+  width: 90%;
   margin: 0 auto;
-  padding: 40px 20px;
+  padding: 2.5rem 1rem;
 
   ${media.mobile} {
-    padding: 20px 10px;
+    width: 95%;
+    padding: 2rem 0.5rem;
   }
 `;
 
 export const NewsGrid = styled.div`
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  gap: 24px;
-  margin-top: 20px;
+  grid-template-columns: repeat(auto-fill, minmax(600px, 1fr));
+  gap: 1.75rem;
+  margin-top: 1.75rem;
 
   ${media.mobile} {
     grid-template-columns: 1fr;
-    gap: 16px;
+    gap: 1.25rem;
   }
 `;
 
 export const NewsCard = styled.div`
+  display: flex;
   border: 1px solid ${SEJONG_COLORS.COOL_GRAY};
   border-radius: 8px;
   overflow: hidden;
@@ -35,20 +37,13 @@ export const NewsCard = styled.div`
 
   &:hover {
     transform: translateY(-4px);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
   }
 `;
 
-export const NewsImageWrapper = styled.div`
-  width: 100%;
-  height: 200px;
-  overflow: hidden;
-  background-color: ${SEJONG_COLORS.COOL_GRAY};
-  position: relative;
-`;
-
 export const NewsImage = styled.div<{ imageUrl: string }>`
-  width: 100%;
+  width: 280px;
+  min-width: 280px;
   height: 200px;
   background-image: url(${(props) => props.imageUrl});
   background-size: cover;
@@ -66,34 +61,29 @@ export const NewsImage = styled.div<{ imageUrl: string }>`
     align-items: center;
     justify-content: center;
     color: ${SEJONG_COLORS.GRAY};
-    font-size: 14px;
+    font-size: 0.875rem;
     &::after {
       content: '이미지를 불러올 수 없습니다';
     }
   }
-`;
 
-export const ImageFallback = styled.div`
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background-color: ${SEJONG_COLORS.COOL_GRAY};
-  color: ${SEJONG_COLORS.GRAY};
-  font-size: 14px;
+  ${media.mobile} {
+    width: 120px;
+    min-width: 120px;
+    height: 120px;
+  }
 `;
 
 export const NewsContent = styled.div`
-  padding: 20px;
+  flex: 1;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
 `;
 
 export const NewsTitle = styled.h3`
   margin: 0;
-  font-size: 18px;
+  font-size: 1.25rem;
   font-weight: 600;
   color: ${SEJONG_COLORS.GRAY};
   line-height: 1.4;
@@ -101,212 +91,114 @@ export const NewsTitle = styled.h3`
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
+  min-height: 2.8rem;
 
   ${media.mobile} {
-    font-size: 16px;
+    font-size: 1.25rem;
   }
 `;
 
 export const NewsDate = styled.p`
-  margin: 8px 0 0 0;
-  font-size: 14px;
+  margin: 1rem 0 0 0;
+  font-size: 0.95rem;
   color: ${SEJONG_COLORS.LIGHT_GRAY};
 `;
 
 export const NewsDescription = styled.p`
-  margin: 12px 0;
-  font-size: 14px;
+  margin: 0.875rem 0;
+  font-size: 1rem;
   color: ${SEJONG_COLORS.WARM_GRAY2};
   line-height: 1.6;
   display: -webkit-box;
-  -webkit-line-clamp: 3;
+  -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
-  height: 4.8em;
+  min-height: 3.2em;
 
   ${media.mobile} {
-    font-size: 13px;
+    font-size: 0.95rem;
+  }
+`;
+
+export const NewsFooter = styled.div`
+  display: flex;
+  align-items: center;
+  margin-top: 1.5rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid ${SEJONG_COLORS.COOL_GRAY}20;
+
+  ${media.mobile} {
+    margin-top: 1.25rem;
+    padding-top: 1.25rem;
   }
 `;
 
 export const NewsViews = styled.span`
   display: flex;
   align-items: center;
-  gap: 4px;
-  font-size: 14px;
+  gap: 0.5rem;
+  font-size: 0.95rem;
   color: ${SEJONG_COLORS.LIGHT_GRAY};
 
   svg {
-    width: 16px;
-    height: 16px;
+    width: 1.25rem;
+    height: 1.25rem;
     color: ${SEJONG_COLORS.WARM_GRAY1};
   }
-`;
-
-export const PaginationButton = styled.button<{
-  direction?: 'prev' | 'next';
-  disabled?: boolean;
-}>`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 8px 12px;
-  min-width: 80px;
-  height: 36px;
-  border: 1px solid
-    ${(props) =>
-      props.disabled ? SEJONG_COLORS.COOL_GRAY : SEJONG_COLORS.CRIMSON_RED};
-  background-color: white;
-  color: ${(props) =>
-    props.disabled ? SEJONG_COLORS.LIGHT_GRAY : SEJONG_COLORS.CRIMSON_RED};
-  font-size: 14px;
-  border-radius: 4px;
-  cursor: ${(props) => (props.disabled ? 'not-allowed' : 'pointer')};
-  transition: all 0.2s;
-
-  &:hover:not(:disabled) {
-    background-color: ${SEJONG_COLORS.IVORY};
-  }
-
-  svg {
-    width: 16px;
-    height: 16px;
-    margin: ${(props) =>
-      props.direction === 'prev' ? '0 4px 0 0' : '0 0 0 4px'};
-  }
-
-  ${media.mobile} {
-    min-width: 60px;
-    padding: 6px 8px;
-    font-size: 13px;
-  }
-`;
-
-export const PageEllipsis = styled.span`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
-  color: ${SEJONG_COLORS.GRAY};
-
-  ${media.mobile} {
-    width: 32px;
-    height: 32px;
-  }
-`;
-
-export const Pagination = styled.nav`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin-top: 40px;
-`;
-
-export const PageList = styled.ul`
-  display: flex;
-  list-style: none;
-  padding: 0;
-  gap: 8px;
-`;
-
-export const PageItem = styled.li`
-  margin: 0;
-  padding: 0;
-`;
-
-export const PageButton = styled.button<{ isActive?: boolean }>`
-  min-width: 36px;
-  height: 36px;
-  padding: 0 12px;
-  border: 1px solid
-    ${(props) =>
-      props.isActive ? SEJONG_COLORS.CRIMSON_RED : SEJONG_COLORS.COOL_GRAY};
-  background: ${(props) =>
-    props.isActive ? SEJONG_COLORS.CRIMSON_RED : 'white'};
-  color: ${(props) => (props.isActive ? 'white' : SEJONG_COLORS.GRAY)};
-  font-size: 14px;
-  border-radius: 4px;
-  cursor: pointer;
-  transition: all 0.2s;
-
-  &:hover {
-    background: ${(props) =>
-      props.isActive ? SEJONG_COLORS.CRIMSON_RED : SEJONG_COLORS.IVORY};
-  }
-
-  &:disabled {
-    background: ${SEJONG_COLORS.COOL_GRAY};
-    border-color: ${SEJONG_COLORS.COOL_GRAY};
-    color: ${SEJONG_COLORS.LIGHT_GRAY};
-    cursor: not-allowed;
-  }
-
-  ${media.mobile} {
-    min-width: 32px;
-    height: 32px;
-    padding: 0 8px;
-    font-size: 13px;
-  }
-`;
-
-export const LoadingSpinner = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  min-height: 200px;
-  color: ${SEJONG_COLORS.CRIMSON_RED};
-`;
-
-export const ErrorMessage = styled.div`
-  text-align: center;
-  padding: 40px;
-  color: ${SEJONG_COLORS.CRIMSON_RED};
-  font-size: 16px;
-`;
-
-export const NoResults = styled.div`
-  text-align: center;
-  padding: 40px;
-  color: ${SEJONG_COLORS.GRAY};
-  font-size: 16px;
 `;
 
 export const AdminButtonGroup = styled.div`
   display: flex;
   justify-content: flex-end;
-  margin-bottom: 20px;
+  margin-bottom: 2rem;
 
   ${media.mobile} {
-    margin-bottom: 16px;
+    margin-bottom: 1.5rem;
   }
 `;
 
 export const CreateButton = styled.button`
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 16px;
+  gap: 0.75rem;
+  padding: 0.75rem 1.5rem;
   background-color: ${SEJONG_COLORS.CRIMSON_RED};
   color: white;
   border: none;
-  border-radius: 4px;
-  font-size: 14px;
+  border-radius: 6px;
+  font-size: 1rem;
+  font-weight: 500;
   cursor: pointer;
   transition: all 0.2s ease;
 
   &:hover {
     background-color: ${SEJONG_COLORS.DARK_RED};
+    box-shadow: 0 2px 4px rgba(139, 0, 0, 0.2);
+  }
+
+  &:active {
+    transform: translateY(1px);
+    box-shadow: none;
   }
 
   svg {
-    width: 20px;
-    height: 20px;
+    width: 1.25rem;
+    height: 1.25rem;
   }
 
   ${media.mobile} {
-    padding: 6px 12px;
-    font-size: 13px;
+    padding: 0.625rem 1.25rem;
+    font-size: 0.95rem;
+  }
+`;
+
+export const AdminActions = styled.div`
+  display: flex;
+  gap: 0.5rem;
+  margin-left: auto;
+
+  ${media.mobile} {
+    gap: 0.375rem;
   }
 `;
 
@@ -314,9 +206,9 @@ export const ActionButton = styled.button`
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 6px;
+  padding: 0.5rem;
   border: 1px solid ${SEJONG_COLORS.COOL_GRAY};
-  border-radius: 4px;
+  border-radius: 6px;
   background: white;
   color: ${SEJONG_COLORS.GRAY};
   cursor: pointer;
@@ -334,39 +226,148 @@ export const ActionButton = styled.button`
   }
 
   svg {
-    width: 16px;
-    height: 16px;
+    width: 1.25rem;
+    height: 1.25rem;
   }
 
   ${media.mobile} {
-    padding: 4px;
+    padding: 0.375rem;
 
     svg {
-      width: 14px;
-      height: 14px;
+      width: 1.125rem;
+      height: 1.125rem;
     }
   }
 `;
 
-export const AdminActions = styled.div`
+export const Pagination = styled.nav`
   display: flex;
-  gap: 8px;
-  margin-left: auto;
+  justify-content: center;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 3rem;
+  padding-top: 2rem;
+  border-top: 1px solid ${SEJONG_COLORS.COOL_GRAY}20;
+`;
+
+export const PageList = styled.ul`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+`;
+
+export const PageItem = styled.li`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const PageButton = styled.button<{ isActive?: boolean }>`
+  min-width: 2.5rem;
+  height: 2.5rem;
+  padding: 0 0.75rem;
+  border: 1px solid
+    ${(props) =>
+      props.isActive ? SEJONG_COLORS.CRIMSON_RED : SEJONG_COLORS.COOL_GRAY};
+  background: ${(props) =>
+    props.isActive ? SEJONG_COLORS.CRIMSON_RED : 'white'};
+  color: ${(props) => (props.isActive ? 'white' : SEJONG_COLORS.GRAY)};
+  font-size: 1rem;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+
+  &:hover:not(:disabled) {
+    background: ${(props) =>
+      props.isActive ? '#8b0000' : SEJONG_COLORS.COOL_GRAY}10;
+    border-color: ${(props) =>
+      props.isActive ? '#8b0000' : SEJONG_COLORS.CRIMSON_RED};
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+
+  &:active:not(:disabled) {
+    transform: translateY(1px);
+  }
 
   ${media.mobile} {
-    gap: 6px;
+    min-width: 2.25rem;
+    height: 2.25rem;
+    padding: 0 0.5rem;
+    font-size: 0.95rem;
   }
 `;
 
-export const NewsFooter = styled.div`
+export const PaginationButton = styled.button<{
+  direction?: 'prev' | 'next';
+  disabled?: boolean;
+}>`
   display: flex;
   align-items: center;
-  margin-top: 12px;
-  padding-top: 12px;
-  border-top: 1px solid ${SEJONG_COLORS.COOL_GRAY};
+  justify-content: center;
+  padding: 0.75rem 1.5rem;
+  min-width: 6rem;
+  border: 1px solid
+    ${(props) =>
+      props.disabled ? SEJONG_COLORS.COOL_GRAY : SEJONG_COLORS.CRIMSON_RED};
+  background-color: white;
+  color: ${(props) =>
+    props.disabled ? SEJONG_COLORS.LIGHT_GRAY : SEJONG_COLORS.CRIMSON_RED};
+  font-size: 1rem;
+  border-radius: 6px;
+  cursor: ${(props) => (props.disabled ? 'not-allowed' : 'pointer')};
+  transition: all 0.2s ease-in-out;
+
+  &:hover:not(:disabled) {
+    background: ${SEJONG_COLORS.COOL_GRAY}10;
+    border-color: ${(props) =>
+      props.disabled ? SEJONG_COLORS.COOL_GRAY : '#8b0000'};
+  }
+
+  &:active:not(:disabled) {
+    transform: translateY(1px);
+  }
 
   ${media.mobile} {
-    margin-top: 10px;
-    padding-top: 10px;
+    padding: 0.625rem 1rem;
+    min-width: 5rem;
+    font-size: 0.95rem;
   }
+`;
+
+export const LoadingSpinner = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 300px;
+  color: ${SEJONG_COLORS.CRIMSON_RED};
+  font-size: 1.125rem;
+`;
+
+export const ErrorMessage = styled.div`
+  text-align: center;
+  padding: 2.5rem;
+  margin: 2rem 0;
+  color: ${SEJONG_COLORS.CRIMSON_RED};
+  font-size: 1.125rem;
+  background-color: #fff5f5;
+  border-radius: 8px;
+  border: 1px solid ${SEJONG_COLORS.CRIMSON_RED}20;
+`;
+
+export const NoResults = styled.div`
+  text-align: center;
+  padding: 3rem;
+  color: ${SEJONG_COLORS.GRAY};
+  background-color: ${SEJONG_COLORS.COOL_GRAY}10;
+  border: 1px solid ${SEJONG_COLORS.COOL_GRAY};
+  border-radius: 8px;
+  margin-top: 2rem;
+  font-size: 1.125rem;
 `;

--- a/frontend/src/pages/News/NoticeBoard/hooks/useNoticeBoard.ts
+++ b/frontend/src/pages/News/NoticeBoard/hooks/useNoticeBoard.ts
@@ -60,7 +60,10 @@ export const useNoticeBoard = () => {
 
       if (allowedSortFields.includes(state.filters.sort.field)) {
         params.append('sort', state.filters.sort.field);
-        params.append('sortDirection', state.filters.sort.direction.toUpperCase());
+        params.append(
+          'sortDirection',
+          state.filters.sort.direction.toUpperCase(),
+        );
       }
 
       const response = await axios.get<ApiResponse>(


### PR DESCRIPTION
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

# News Feature Implementation PR

## 구현 내용
새로운 뉴스 관리 시스템 구현 (CRUD + 슬라이더)

### 주요 컴포넌트
1. **NewsSlider**
   - 반응형 뉴스 슬라이더 구현
   - 화면 크기에 따른 동적 아이템 개수 조절
   - 자동 슬라이드 + 마우스 오버시 일시정지
   - 기본 슬라이드 간격: 5초

2. **NewsCard**
   - 뉴스 카드 UI 컴포넌트
   - 이미지, 제목, 날짜, 조회수 표시
   - 이미지 로드 실패시 폴백 처리

3. **News (메인 목록)**
   - 페이지네이션 구현
   - 관리자용 CRUD 기능
   - 반응형 그리드 레이아웃

### 기술 스택
- React + TypeScript
- styled-components
- moment.js (날짜 처리)
- lucide-react (아이콘)
- react-quill (에디터)

### 주요 기능
- **뉴스 CRUD**
  - 생성/수정시 이미지 업로드
  - 리치텍스트 에디터 지원
  - AWS S3 이미지 저장

- **슬라이더**
  - 반응형 디자인
    - 모바일: 1개
    - 태블릿: 2개
    - 데스크탑: 4개
  - 터치/스와이프 지원

### 개선사항
1. 이미지 최적화 필요
2. 에러 바운더리 추가 고려
3. 성능 모니터링 추가 검토

### API 엔드포인트
```
GET    /api/news          // 목록 조회
GET    /api/news/:id      // 상세 조회
POST   /api/news          // 생성
PUT    /api/news/:id      // 수정
DELETE /api/news/:id      // 삭제
```

## 주의사항
- 이미지 업로드 시 5MB 제한
- S3 버킷 권한 설정 필요


Closes #245