### PR TITLE
[FE] 메인 페이지의 공지사항에 작성 날짜가 뜨지 않는 현상 수정

### DIFF
--- a/frontend/src/pages/Main/Main.tsx
+++ b/frontend/src/pages/Main/Main.tsx
@@ -88,8 +88,7 @@ const announcementTab: string[] = ['학부', '대학원', '취업', '장학'];
 
 interface Announcement {
   category: string;
-  createDate: string;
-  // file: string;
+  createdDate: string;
   id: number;
   title: string;
   viewCount: number;
@@ -254,7 +253,7 @@ function Main(): JSX.Element {
                       <img src="/bullet.svg" alt="bullet" />
                       {announcement.title}
                     </span>
-                    <span>{announcement.createDate}</span>
+                    <span>{announcement.createdDate}</span>
                   </AnnouncementItem>
                 ))
               )}


### PR DESCRIPTION
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?

## 작업 내용
메인 페이지의 공지사항 부분에 작성 날짜가 뜨도록 수정

## 스크린샷
![localhost_3000_ (2)](https://github.com/user-attachments/assets/1af0ab9f-00f0-402b-b132-3ec9ae59dd92)

Closes #279 