### PR TITLE
[BE] 세종대 구성원(교수, 교직원, 학생) 통합 로그인 로직 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -31,6 +31,8 @@ dependencies {
     implementation 'ch.qos.logback:logback-classic'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'	//Swagger
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    //jsoup
+    implementation 'org.jsoup:jsoup:1.14.3'
 
     // security
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/backend/src/main/java/org/example/backend/users/dto/SjLoginReq.java
+++ b/backend/src/main/java/org/example/backend/users/dto/SjLoginReq.java
@@ -1,0 +1,19 @@
+package org.example.backend.users.dto;
+
+public class SjLoginReq {
+    private final String userId;
+    private final String password;
+
+    public SjLoginReq(String userId, String password) {
+        this.userId = userId;
+        this.password = password;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+}

--- a/backend/src/main/java/org/example/backend/users/dto/SjUserProfile.java
+++ b/backend/src/main/java/org/example/backend/users/dto/SjUserProfile.java
@@ -1,0 +1,19 @@
+package org.example.backend.users.dto;
+
+public class SjUserProfile {
+    private final String name;
+    private final String major;
+
+    public SjUserProfile(String name, String major) {
+        this.name = name;
+        this.major = major;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getMajor() {
+        return major;
+    }
+}

--- a/backend/src/main/java/org/example/backend/users/service/SjAuthService.java
+++ b/backend/src/main/java/org/example/backend/users/service/SjAuthService.java
@@ -1,0 +1,61 @@
+package org.example.backend.users.service;
+
+
+import java.io.IOException;
+import org.example.backend.users.dto.SjLoginReq;
+import org.example.backend.users.dto.SjUserProfile;
+import org.springframework.security.core.AuthenticationException;
+import org.jsoup.Connection;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.springframework.stereotype.Component;
+
+
+@Component
+public class SjAuthService {
+    private final String MOODLER_LOGIN_URL = "https://sjulms.moodler.kr/login/index.php";
+    private final String AUTH_FAILED = "인증에 실패하였습니다.";
+    private final String USER_INFO_MISSING = "사용자 정보를 찾을 수 없습니다.";
+
+    public SjUserProfile authenticate(SjLoginReq loginRequest) throws AuthenticationException {
+        try {
+            Connection.Response response = executeLoginRequest(loginRequest);
+
+            if (response.statusCode() != 200) {
+                throw new RuntimeException("서버 오류가 발생했습니다: HTTP " + response.statusCode());
+            }
+
+            return parseUserProfile(response.parse());
+        } catch (IOException e) {
+            throw new RuntimeException("Error: " + e.getMessage());
+        }
+    }
+
+    private Connection.Response executeLoginRequest(SjLoginReq loginRequest) throws IOException {
+        return Jsoup.connect(MOODLER_LOGIN_URL)
+                .data("username", loginRequest.getUserId())
+                .data("password", loginRequest.getPassword())
+                .method(Connection.Method.POST)
+                .execute();
+    }
+
+    private SjUserProfile parseUserProfile(Document document) throws AuthenticationException {
+        Element userInfo = document.selectFirst("div.user-info-picture");
+        if (userInfo == null) {
+            throw new RuntimeException(AUTH_FAILED);
+        }
+
+        Element nameElement = document.selectFirst("h4");
+        Element majorElement = document.selectFirst("p.department");
+
+        if (nameElement == null || majorElement == null) {
+            throw new RuntimeException(USER_INFO_MISSING);
+        }
+
+        return new SjUserProfile(
+                nameElement.text().trim(),
+                majorElement.text().trim()
+        );
+    }
+}

--- a/backend/src/test/java/org/example/backend/ControllerTestSupport.java
+++ b/backend/src/test/java/org/example/backend/ControllerTestSupport.java
@@ -8,7 +8,6 @@ import org.example.backend.department.service.DepartmentService;
 import org.example.backend.jwt.JWTUtil;
 import org.example.backend.professor.controller.ProfessorController;
 import org.example.backend.professor.service.ProfessorService;
-import org.example.backend.user.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -35,11 +34,9 @@ public abstract class ControllerTestSupport {
 
     @MockBean
     protected ProfessorService professorService;
-    @MockBean
-    protected AdminService adminService;
 
     @MockBean
-    protected UserService userService;
+    protected AdminService adminService;
 
     @MockBean
     protected JWTUtil jwtUtil;

--- a/backend/src/test/java/org/example/backend/SjTest.java
+++ b/backend/src/test/java/org/example/backend/SjTest.java
@@ -1,22 +1,26 @@
 package org.example.backend;
 
+import org.example.backend.users.dto.SjLoginReq;
+import org.example.backend.users.dto.SjUserProfile;
+import org.example.backend.users.service.SjAuthService;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.yj.sejongauth.controller.Sj;
-import org.yj.sejongauth.domain.SjProfile;
+
 
 @SpringBootTest
 public class SjTest {
 
     @Autowired
-    protected Sj sj;
+    SjAuthService sjAuthService;
 
     @Test
     @Disabled
     void SjTest(){
-        SjProfile sjProfile = sj.login("학번", "비번");
-        System.out.println(sjProfile);
+        SjLoginReq test = new SjLoginReq("test", "test");
+        SjUserProfile sjProfile = sjAuthService.authenticate(test);
+        System.out.println(sjProfile.getMajor());
+        System.out.println(sjProfile.getName());
     }
 }

--- a/backend/src/test/java/org/example/backend/professor/service/ProfessorServiceTest.java
+++ b/backend/src/test/java/org/example/backend/professor/service/ProfessorServiceTest.java
@@ -72,7 +72,7 @@ public class ProfessorServiceTest extends IntegrationTestSupport {
         ProfessorException exception = assertThrows(ProfessorException.class,
                 () -> professorService.saveProfessor(dto, null));
 
-        assertEquals(ProfessorExceptionType.REQUIRED_NAME, exception.exceptionType());
+        assertEquals(ProfessorExceptionType.NOT_FOUND_PROFESSOR, exception.exceptionType());
     }
 
     @Test


### PR DESCRIPTION
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
기존 파싱 사이트를 세종대 대양휴머니티칼리지에서 세종대 lms로 변경.
이유
대양휴머니티칼리지는 학생에 특화되있는 반면 lms는 전 구성원의 개인정보관리에 초점이 있어 교직원, 교수도 동등하게 학과, 정보 가져올수있음.
(교수는 테스트X).

## 사용방법
테스트 참고. 사용자 객체 생성 -> service 요청.
## 스크린샷
학생
<img width="76" alt="스크린샷 2025-01-19 오후 3 31 00" src="https://github.com/user-attachments/assets/29f803ac-6854-48ee-b1a4-f33d1e37e6f2" />
교직원
<img width="110" alt="스크린샷 2025-01-19 오후 3 31 30" src="https://github.com/user-attachments/assets/d1dda079-76f0-4ce7-96dd-81c0c7d58685" />

## 주의사항
전처럼 학교에서 api로직을 변경할경우 다시 수정이 필요함.
커스텀 예외처리 미적용. 왜? -> 필터에서 처리하는 예외처리를 적용시키는게 나아보이는데 이 부분 건의사항이 있음.

## 건의사항
### 학교포털로그인로직적용위치

로직은 작성했으나 3가지 위치 중 고민중

1. 컨트롤러
2. 인터셉터
3. 필터

전에는 컨트롤러에서 처리를 했으나 인증, 인가 로직은 컨트롤러측에서 처리하는게 아니라고 판단

그래서 2, 3으로 처리하려고 했으나 관리자, 유저도 똑같이 jwt를 사용하는게 맞다고 생각해서 3 필터측에서 처리하는게 가장 적합하다고 생각.

기존에는 유저, 관리자 2개를 나눠서 관리했음. 그러나 로직 중복을 줄이고 jwt rule을 이용해 통합 관리 사용하는게 어떤지?

필터에서 2개의 로직을 처리 후 한번에 관리하는게 깔끔하다고 생각

예상 흐름
-----
필터 req -> 관리자 인지? db 조회
맞다면 관리자 (관리자 jwt 발급)
틀리면 -> 학생인지?
맞다면 학생 (학생 jwt 발급)
틀리면 -> 에러
rule에 맞게 해당 컨트롤러 인가 처리.

의견부탁입니당
Closes #282 