### PR TITLE
[BE][FEAT] 뉴스, 공지, 세미나, 논문 검색기능

### DIFF
--- a/backend/src/main/java/org/example/backend/board/controller/BoardController.java
+++ b/backend/src/main/java/org/example/backend/board/controller/BoardController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.backend.board.domain.dto.BoardReqDto;
 import org.example.backend.board.domain.dto.BoardResDto;
+import org.example.backend.board.domain.entity.Board;
 import org.example.backend.board.domain.entity.Category;
 import org.example.backend.board.service.BoardService;
 import org.example.backend.common.dto.PageRequestDto;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -53,6 +55,7 @@ public class BoardController {
         Page<BoardResDto> boardList = boardService.getAllBoards(pageRequest.toPageable());
         return ResponseDto.ok(boardList.getNumber(), boardList.getTotalPages(), boardList.getContent());
     }
+
     @Operation(summary = "카테고리별 게시판 조회 API", description = "카테고리별 게시판 리스트 반환")
     @GetMapping("/category/{category}")
     public ResponseDto<List<BoardResDto>> getBoardsByCategory(@PathVariable("category") Category category,
@@ -88,5 +91,11 @@ public class BoardController {
     public ResponseEntity<?> deleteBoard(@PathVariable(name = "boardId") Long boardId) {
         boardService.deleteBoard(boardId);
         return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @Operation(summary = "키워드 검색 API", description = "키워드 검색")
+    @GetMapping("/search")
+    public List<Board> searchBoard(@RequestParam String keyword) {
+        return boardService.searchBoard(keyword);
     }
 }

--- a/backend/src/main/java/org/example/backend/board/controller/BoardController.java
+++ b/backend/src/main/java/org/example/backend/board/controller/BoardController.java
@@ -10,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.backend.board.domain.dto.BoardReqDto;
 import org.example.backend.board.domain.dto.BoardResDto;
-import org.example.backend.board.domain.entity.Board;
 import org.example.backend.board.domain.entity.Category;
 import org.example.backend.board.service.BoardService;
 import org.example.backend.common.dto.PageRequestDto;
@@ -95,7 +94,9 @@ public class BoardController {
 
     @Operation(summary = "키워드 검색 API", description = "키워드 검색")
     @GetMapping("/search")
-    public List<Board> searchBoard(@RequestParam String keyword) {
-        return boardService.searchBoard(keyword);
+    public ResponseDto<List<BoardResDto>> searchBoard(@RequestParam String keyword,
+                                                      @ModelAttribute @Valid PageRequestDto pageRequest) {
+        Page<BoardResDto> boardList = boardService.searchBoard(keyword, pageRequest.toPageable());
+        return ResponseDto.ok(boardList.getNumber(), boardList.getTotalPages(), boardList.getContent());
     }
 }

--- a/backend/src/main/java/org/example/backend/board/repository/BoardRepository.java
+++ b/backend/src/main/java/org/example/backend/board/repository/BoardRepository.java
@@ -1,5 +1,6 @@
 package org.example.backend.board.repository;
 
+import java.util.List;
 import org.example.backend.board.domain.entity.Board;
 import org.example.backend.board.domain.entity.Category;
 import org.springframework.data.domain.Page;
@@ -11,8 +12,12 @@ import org.springframework.data.repository.query.Param;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
     Page<Board> findAllByCategory(Category category, Pageable pageable);
+
     @Modifying
     @Query("UPDATE Board b SET b.viewCount = b.viewCount + 1 WHERE b.id = :boardId")
     void incrementViewCount(@Param("boardId") Long boardId);
 
+    // name(title) 또는 content에서 키워드를 포함하는 데이터 검색
+    @Query("SELECT b FROM Board b WHERE b.title LIKE %:keyword%")
+    List<Board> searchByKeyword(@Param("keyword") String keyword);
 }

--- a/backend/src/main/java/org/example/backend/board/repository/BoardRepository.java
+++ b/backend/src/main/java/org/example/backend/board/repository/BoardRepository.java
@@ -1,6 +1,5 @@
 package org.example.backend.board.repository;
 
-import java.util.List;
 import org.example.backend.board.domain.entity.Board;
 import org.example.backend.board.domain.entity.Category;
 import org.springframework.data.domain.Page;
@@ -19,5 +18,5 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
 
     // name(title) 또는 content에서 키워드를 포함하는 데이터 검색
     @Query("SELECT b FROM Board b WHERE b.title LIKE %:keyword%")
-    List<Board> searchByKeyword(@Param("keyword") String keyword);
+    Page<Board> searchByKeyword(@Param("keyword") String keyword, Pageable pageable);
 }

--- a/backend/src/main/java/org/example/backend/board/service/BoardService.java
+++ b/backend/src/main/java/org/example/backend/board/service/BoardService.java
@@ -128,7 +128,8 @@ public class BoardService {
         boardRepository.incrementViewCount(boardId);
     }
 
-    public List<Board> searchBoard(String keyword) {
-        return boardRepository.searchByKeyword(keyword);
+    public Page<BoardResDto> searchBoard(String keyword, Pageable pageable) {
+        return boardRepository.searchByKeyword(keyword, pageable)
+                .map(BoardResDto::of);
     }
 }

--- a/backend/src/main/java/org/example/backend/board/service/BoardService.java
+++ b/backend/src/main/java/org/example/backend/board/service/BoardService.java
@@ -42,6 +42,7 @@ public class BoardService {
         Board savedBoard = boardRepository.save(board);
         return savedBoard.getId();
     }
+
     public BoardResDto getBoard(Long boardId) {
         Board board = findBoardById(boardId);
         return BoardResDto.of(board);
@@ -125,5 +126,9 @@ public class BoardService {
     @Transactional
     public void readCount(Long boardId) {
         boardRepository.incrementViewCount(boardId);
+    }
+
+    public List<Board> searchBoard(String keyword) {
+        return boardRepository.searchByKeyword(keyword);
     }
 }

--- a/backend/src/main/java/org/example/backend/news/controller/NewsController.java
+++ b/backend/src/main/java/org/example/backend/news/controller/NewsController.java
@@ -9,6 +9,7 @@ import org.example.backend.common.dto.PageRequestDto;
 import org.example.backend.common.dto.ResponseDto;
 import org.example.backend.news.domain.dto.NewsReqDto;
 import org.example.backend.news.domain.dto.NewsResDto;
+import org.example.backend.news.domain.entity.News;
 import org.example.backend.news.service.NewsService;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -69,5 +71,11 @@ public class NewsController {
     public ResponseEntity<?> deleteNews(@PathVariable(name = "newsId") Long newsId) {
         newsService.deleteNews(newsId);
         return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @Operation(summary = "키워드 검색 API", description = "키워드 검색")
+    @GetMapping("/search")
+    public List<News> searchNews(@RequestParam String keyword) {
+        return newsService.searchNews(keyword);
     }
 }

--- a/backend/src/main/java/org/example/backend/news/controller/NewsController.java
+++ b/backend/src/main/java/org/example/backend/news/controller/NewsController.java
@@ -9,7 +9,6 @@ import org.example.backend.common.dto.PageRequestDto;
 import org.example.backend.common.dto.ResponseDto;
 import org.example.backend.news.domain.dto.NewsReqDto;
 import org.example.backend.news.domain.dto.NewsResDto;
-import org.example.backend.news.domain.entity.News;
 import org.example.backend.news.service.NewsService;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -75,7 +74,9 @@ public class NewsController {
 
     @Operation(summary = "키워드 검색 API", description = "키워드 검색")
     @GetMapping("/search")
-    public List<News> searchNews(@RequestParam String keyword) {
-        return newsService.searchNews(keyword);
+    public ResponseDto<List<NewsResDto>> searchNews(@RequestParam String keyword,
+                                                    @Valid @ModelAttribute PageRequestDto pageRequest) {
+        Page<NewsResDto> newsList = newsService.searchNews(keyword, pageRequest.toPageable());
+        return ResponseDto.ok(newsList.getNumber(), newsList.getTotalPages(), newsList.getContent());
     }
 }

--- a/backend/src/main/java/org/example/backend/news/repository/NewsRepository.java
+++ b/backend/src/main/java/org/example/backend/news/repository/NewsRepository.java
@@ -1,7 +1,14 @@
 package org.example.backend.news.repository;
 
+import java.util.List;
 import org.example.backend.news.domain.entity.News;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface NewsRepository extends JpaRepository<News, Long> {
+
+    // name(title) 또는 content에서 키워드를 포함하는 데이터 검색
+    @Query("SELECT n FROM News n WHERE n.title LIKE %:keyword% OR n.content LIKE %:keyword%")
+    List<News> searchByKeyword(@Param("keyword") String keyword);
 }

--- a/backend/src/main/java/org/example/backend/news/repository/NewsRepository.java
+++ b/backend/src/main/java/org/example/backend/news/repository/NewsRepository.java
@@ -1,7 +1,8 @@
 package org.example.backend.news.repository;
 
-import java.util.List;
 import org.example.backend.news.domain.entity.News;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,5 +11,5 @@ public interface NewsRepository extends JpaRepository<News, Long> {
 
     // name(title) 또는 content에서 키워드를 포함하는 데이터 검색
     @Query("SELECT n FROM News n WHERE n.title LIKE %:keyword% OR n.content LIKE %:keyword%")
-    List<News> searchByKeyword(@Param("keyword") String keyword);
+    Page<News> searchByKeyword(@Param("keyword") String keyword, Pageable pageable);
 }

--- a/backend/src/main/java/org/example/backend/news/service/NewsService.java
+++ b/backend/src/main/java/org/example/backend/news/service/NewsService.java
@@ -2,7 +2,6 @@ package org.example.backend.news.service;
 
 import static org.example.backend.news.exception.NewsExceptionType.NOT_FOUND_NEWS;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.example.backend.global.config.file.LocalFileUploader;
 import org.example.backend.news.domain.dto.NewsReqDto;
@@ -73,7 +72,8 @@ public class NewsService {
                 .map(NewsResDto::of);
     }
 
-    public List<News> searchNews(String keyword) {
-        return newsRepository.searchByKeyword(keyword);
+    public Page<NewsResDto> searchNews(String keyword, Pageable pageable) {
+        return newsRepository.searchByKeyword(keyword, pageable)
+                .map(NewsResDto::of);
     }
 }

--- a/backend/src/main/java/org/example/backend/news/service/NewsService.java
+++ b/backend/src/main/java/org/example/backend/news/service/NewsService.java
@@ -2,6 +2,7 @@ package org.example.backend.news.service;
 
 import static org.example.backend.news.exception.NewsExceptionType.NOT_FOUND_NEWS;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.example.backend.global.config.file.LocalFileUploader;
 import org.example.backend.news.domain.dto.NewsReqDto;
@@ -18,7 +19,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional(readOnly = true) // JPA가 변경 감지(dirty checking)를 하지 않음 -> 조회 성능 최적화
 public class NewsService {
     private final NewsRepository newsRepository;
     private final LocalFileUploader localFileUploader;
@@ -26,6 +27,7 @@ public class NewsService {
 
     @Value("${server.url}")
     private String serverUrl;
+
     @Transactional
     public Long saveNews(NewsReqDto newsReqDto, MultipartFile multipartFile) {
 
@@ -69,5 +71,9 @@ public class NewsService {
     public Page<NewsResDto> getAllNews(Pageable pageable) {
         return newsRepository.findAll(pageable)
                 .map(NewsResDto::of);
+    }
+
+    public List<News> searchNews(String keyword) {
+        return newsRepository.searchByKeyword(keyword);
     }
 }

--- a/backend/src/main/java/org/example/backend/professor/domain/entity/Professor.java
+++ b/backend/src/main/java/org/example/backend/professor/domain/entity/Professor.java
@@ -3,6 +3,7 @@ package org.example.backend.professor.domain.entity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -52,7 +53,7 @@ public class Professor {
     @Column(name = "profileImage", length = 1000)
     private String profileImage;
 
-    @OneToMany(mappedBy = "professor", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "professor", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<Thesis> theses = new ArrayList<>();
 
     @Builder

--- a/backend/src/main/java/org/example/backend/seminar/controller/SeminarController.java
+++ b/backend/src/main/java/org/example/backend/seminar/controller/SeminarController.java
@@ -9,6 +9,7 @@ import org.example.backend.common.dto.PageRequestDto;
 import org.example.backend.common.dto.ResponseDto;
 import org.example.backend.seminar.domain.dto.SeminarReqDto;
 import org.example.backend.seminar.domain.dto.SeminarResDto;
+import org.example.backend.seminar.domain.entity.Seminar;
 import org.example.backend.seminar.service.SeminarService;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -64,5 +66,11 @@ public class SeminarController {
     public ResponseEntity<?> deleteSeminar(@PathVariable(name = "seminarId") Long seminarId) {
         seminarService.deleteSeminar(seminarId);
         return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @Operation(summary = "키워드 검색 API", description = "키워드 검색")
+    @GetMapping("/search")
+    public List<Seminar> searchSeminar(@RequestParam String keyword) {
+        return seminarService.searchSeminar(keyword);
     }
 }

--- a/backend/src/main/java/org/example/backend/seminar/controller/SeminarController.java
+++ b/backend/src/main/java/org/example/backend/seminar/controller/SeminarController.java
@@ -9,7 +9,6 @@ import org.example.backend.common.dto.PageRequestDto;
 import org.example.backend.common.dto.ResponseDto;
 import org.example.backend.seminar.domain.dto.SeminarReqDto;
 import org.example.backend.seminar.domain.dto.SeminarResDto;
-import org.example.backend.seminar.domain.entity.Seminar;
 import org.example.backend.seminar.service.SeminarService;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -70,7 +69,9 @@ public class SeminarController {
 
     @Operation(summary = "키워드 검색 API", description = "키워드 검색")
     @GetMapping("/search")
-    public List<Seminar> searchSeminar(@RequestParam String keyword) {
-        return seminarService.searchSeminar(keyword);
+    public ResponseDto<List<SeminarResDto>> searchSeminar(@RequestParam String keyword,
+                                                          @Valid @ModelAttribute PageRequestDto pageRequest) {
+        Page<SeminarResDto> seminarList = seminarService.searchSeminar(keyword, pageRequest.toPageable());
+        return ResponseDto.ok(seminarList.getNumber(), seminarList.getTotalPages(), seminarList.getContent());
     }
 }

--- a/backend/src/main/java/org/example/backend/seminar/repository/SeminarRepository.java
+++ b/backend/src/main/java/org/example/backend/seminar/repository/SeminarRepository.java
@@ -1,7 +1,13 @@
 package org.example.backend.seminar.repository;
 
+import java.util.List;
 import org.example.backend.seminar.domain.entity.Seminar;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SeminarRepository extends JpaRepository<Seminar, Long> {
+    // name, speaker, company, place에서 키워드를 포함하는 데이터 검색
+    @Query("SELECT s FROM Seminar s WHERE s.name LIKE %:keyword% OR s.speaker LIKE %:keyword% OR s.company LIKE %:keyword% OR s.place LIKE %:keyword%")
+    List<Seminar> searchByKeyword(@Param("keyword") String keyword);
 }

--- a/backend/src/main/java/org/example/backend/seminar/repository/SeminarRepository.java
+++ b/backend/src/main/java/org/example/backend/seminar/repository/SeminarRepository.java
@@ -1,7 +1,8 @@
 package org.example.backend.seminar.repository;
 
-import java.util.List;
 import org.example.backend.seminar.domain.entity.Seminar;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -9,5 +10,5 @@ import org.springframework.data.repository.query.Param;
 public interface SeminarRepository extends JpaRepository<Seminar, Long> {
     // name, speaker, company, place에서 키워드를 포함하는 데이터 검색
     @Query("SELECT s FROM Seminar s WHERE s.name LIKE %:keyword% OR s.speaker LIKE %:keyword% OR s.company LIKE %:keyword% OR s.place LIKE %:keyword%")
-    List<Seminar> searchByKeyword(@Param("keyword") String keyword);
+    Page<Seminar> searchByKeyword(@Param("keyword") String keyword, Pageable pageable);
 }

--- a/backend/src/main/java/org/example/backend/seminar/service/SeminarService.java
+++ b/backend/src/main/java/org/example/backend/seminar/service/SeminarService.java
@@ -2,7 +2,6 @@ package org.example.backend.seminar.service;
 
 import static org.example.backend.seminar.exception.SeminarExceptionType.NOT_FOUND_SEMINAR;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.example.backend.seminar.domain.dto.SeminarReqDto;
 import org.example.backend.seminar.domain.dto.SeminarResDto;
@@ -55,7 +54,8 @@ public class SeminarService {
                 .map(SeminarResDto::of);
     }
 
-    public List<Seminar> searchSeminar(String keyword) {
-        return seminarRepository.searchByKeyword(keyword);
+    public Page<SeminarResDto> searchSeminar(String keyword, Pageable pageable) {
+        return seminarRepository.searchByKeyword(keyword, pageable)
+                .map(SeminarResDto::of);
     }
 }

--- a/backend/src/main/java/org/example/backend/seminar/service/SeminarService.java
+++ b/backend/src/main/java/org/example/backend/seminar/service/SeminarService.java
@@ -2,12 +2,12 @@ package org.example.backend.seminar.service;
 
 import static org.example.backend.seminar.exception.SeminarExceptionType.NOT_FOUND_SEMINAR;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.example.backend.seminar.domain.dto.SeminarReqDto;
 import org.example.backend.seminar.domain.dto.SeminarResDto;
 import org.example.backend.seminar.domain.entity.Seminar;
 import org.example.backend.seminar.exception.SeminarException;
-import org.example.backend.seminar.exception.SeminarExceptionType;
 import org.example.backend.seminar.repository.SeminarRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -53,5 +53,9 @@ public class SeminarService {
     public Page<SeminarResDto> getAllSeminars(Pageable pageable) {
         return seminarRepository.findAll(pageable)
                 .map(SeminarResDto::of);
+    }
+
+    public List<Seminar> searchSeminar(String keyword) {
+        return seminarRepository.searchByKeyword(keyword);
     }
 }

--- a/backend/src/main/java/org/example/backend/thesis/controller/ThesisController.java
+++ b/backend/src/main/java/org/example/backend/thesis/controller/ThesisController.java
@@ -9,6 +9,7 @@ import org.example.backend.common.dto.PageRequestDto;
 import org.example.backend.common.dto.ResponseDto;
 import org.example.backend.thesis.domain.dto.ThesisReqDto;
 import org.example.backend.thesis.domain.dto.ThesisResDto;
+import org.example.backend.thesis.domain.entity.Thesis;
 import org.example.backend.thesis.service.ThesisService;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -68,5 +70,11 @@ public class ThesisController {
     public ResponseEntity<?> deleteThesis(@PathVariable(name = "thesisId") Long thesisId) {
         thesisService.deleteThesis(thesisId);
         return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @Operation(summary = "키워드 검색 API", description = "키워드 검색")
+    @GetMapping("/search")
+    public List<Thesis> searchThesis(@RequestParam String keyword) {
+        return thesisService.searchThesis(keyword);
     }
 }

--- a/backend/src/main/java/org/example/backend/thesis/controller/ThesisController.java
+++ b/backend/src/main/java/org/example/backend/thesis/controller/ThesisController.java
@@ -9,7 +9,6 @@ import org.example.backend.common.dto.PageRequestDto;
 import org.example.backend.common.dto.ResponseDto;
 import org.example.backend.thesis.domain.dto.ThesisReqDto;
 import org.example.backend.thesis.domain.dto.ThesisResDto;
-import org.example.backend.thesis.domain.entity.Thesis;
 import org.example.backend.thesis.service.ThesisService;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -74,7 +73,9 @@ public class ThesisController {
 
     @Operation(summary = "키워드 검색 API", description = "키워드 검색")
     @GetMapping("/search")
-    public List<Thesis> searchThesis(@RequestParam String keyword) {
-        return thesisService.searchThesis(keyword);
+    public ResponseDto<List<ThesisResDto>> searchThesis(@RequestParam String keyword,
+                                                        @Valid @ModelAttribute PageRequestDto pageRequest) {
+        Page<ThesisResDto> thesisResDtos = thesisService.searchThesis(keyword, pageRequest.toPageable());
+        return ResponseDto.ok(thesisResDtos.getNumber(), thesisResDtos.getTotalPages(), thesisResDtos.getContent());
     }
 }

--- a/backend/src/main/java/org/example/backend/thesis/repository/ThesisRepository.java
+++ b/backend/src/main/java/org/example/backend/thesis/repository/ThesisRepository.java
@@ -1,10 +1,18 @@
 package org.example.backend.thesis.repository;
 
+import java.util.List;
 import org.example.backend.thesis.domain.entity.Thesis;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ThesisRepository extends JpaRepository<Thesis, Long> {
     Page<Thesis> findByProfessorId(Long professorId, Pageable pageable);
+
+    // title, author, journal, content 에서 키워드를 포함하는 데이터 검색
+    @Query("SELECT t FROM Thesis t WHERE t.title LIKE %:keyword% OR t.author LIKE %:keyword% "
+            + "OR t.journal LIKE %:keyword% OR t.content LIKE %:keyword%")
+    List<Thesis> searchByKeyword(@Param("keyword") String keyword);
 }

--- a/backend/src/main/java/org/example/backend/thesis/repository/ThesisRepository.java
+++ b/backend/src/main/java/org/example/backend/thesis/repository/ThesisRepository.java
@@ -1,6 +1,5 @@
 package org.example.backend.thesis.repository;
 
-import java.util.List;
 import org.example.backend.thesis.domain.entity.Thesis;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,7 +11,8 @@ public interface ThesisRepository extends JpaRepository<Thesis, Long> {
     Page<Thesis> findByProfessorId(Long professorId, Pageable pageable);
 
     // title, author, journal, content 에서 키워드를 포함하는 데이터 검색
-    @Query("SELECT t FROM Thesis t WHERE t.title LIKE %:keyword% OR t.author LIKE %:keyword% "
+    // fetch join 사용하여 N+1 문제 해결 (Lazy Loading을 무시하고, 한 번의 쿼리로 논문과 교수 정보를 미리 가져옴)
+    @Query("SELECT t FROM Thesis t JOIN FETCH t.professor WHERE t.title LIKE %:keyword% OR t.author LIKE %:keyword% "
             + "OR t.journal LIKE %:keyword% OR t.content LIKE %:keyword%")
-    List<Thesis> searchByKeyword(@Param("keyword") String keyword);
+    Page<Thesis> searchByKeyword(@Param("keyword") String keyword, Pageable pageable);
 }

--- a/backend/src/main/java/org/example/backend/thesis/service/ThesisService.java
+++ b/backend/src/main/java/org/example/backend/thesis/service/ThesisService.java
@@ -2,6 +2,7 @@ package org.example.backend.thesis.service;
 
 import static org.example.backend.thesis.exception.ThesisExceptionType.NOT_FOUND_THESIS;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.example.backend.global.config.file.LocalFileUploader;
 import org.example.backend.professor.domain.entity.Professor;
@@ -29,6 +30,7 @@ public class ThesisService {
 
     @Value("${server.url}")
     private String serverUrl;
+
     @Transactional
     public Long saveThesis(ThesisReqDto thesisReqDto, MultipartFile multipartFile) {
         Professor professor = findProfessorById(thesisReqDto.getProfessorId());
@@ -87,5 +89,9 @@ public class ThesisService {
     private Thesis findThesisById(Long thesisId) {
         return thesisRepository.findById(thesisId)
                 .orElseThrow(() -> new ThesisException(NOT_FOUND_THESIS));
+    }
+
+    public List<Thesis> searchThesis(String keyword) {
+        return thesisRepository.searchByKeyword(keyword);
     }
 }

--- a/backend/src/main/java/org/example/backend/thesis/service/ThesisService.java
+++ b/backend/src/main/java/org/example/backend/thesis/service/ThesisService.java
@@ -2,7 +2,6 @@ package org.example.backend.thesis.service;
 
 import static org.example.backend.thesis.exception.ThesisExceptionType.NOT_FOUND_THESIS;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.example.backend.global.config.file.LocalFileUploader;
 import org.example.backend.professor.domain.entity.Professor;
@@ -91,7 +90,8 @@ public class ThesisService {
                 .orElseThrow(() -> new ThesisException(NOT_FOUND_THESIS));
     }
 
-    public List<Thesis> searchThesis(String keyword) {
-        return thesisRepository.searchByKeyword(keyword);
+    public Page<ThesisResDto> searchThesis(String keyword, Pageable pageable) {
+        return thesisRepository.searchByKeyword(keyword, pageable)
+                .map(ThesisResDto::of);
     }
 }


### PR DESCRIPTION
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용


## 스크린샷
### 1. 학부뉴스 제목, 내용 기반 검색기능 구현, 페이징 처리
<img width="1402" alt="image" src="https://github.com/user-attachments/assets/9163b88b-9848-406d-959b-a72a45c29c5c" />


### 2. 공지사항 제목 기반 검색기능 구현, 페이징 처리
<img width="1399" alt="image" src="https://github.com/user-attachments/assets/a33aad43-696a-4ec9-9457-b12fc8403f0f" />


### 3. 세미나 이름, 발표자, 소속, 장소 기반 검색기능 구현, 페이징 처리
<img width="1393" alt="image" src="https://github.com/user-attachments/assets/8746e5c2-0354-4760-81a3-17628b02debd" />


### 4. 논문 제목,저자,저널,내용 기반 검색기능 구현 
N+1 문제 발생(교수, 논문) 서로 다른 교수를 참조할수록 추가적인 SELECT 쿼리가 많아질 위험이 있음.
<img width="1407" alt="image" src="https://github.com/user-attachments/assets/7d0f5118-273e-4b0b-b978-216e71812a89" />
fetch join 사용해 즉시 로딩 동작으로 해결
<img width="1407" alt="image" src="https://github.com/user-attachments/assets/0090fee4-0c02-4757-88a5-5aa17f413c48" />



## 주의사항