### PR TITLE
[BE] [FEAT] 비밀번호 유효 검사 기능 구현

### DIFF
--- a/backend/src/main/java/org/example/backend/users/controller/admin/AdminController.java
+++ b/backend/src/main/java/org/example/backend/users/controller/admin/AdminController.java
@@ -11,6 +11,7 @@ import org.example.backend.users.service.AdminService;
 import org.example.backend.users.service.MemberService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -39,6 +40,14 @@ public class AdminController {
         log.info("entered logout api");
         memberService.logout(accessToken, body.get("refreshToken"));
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build(); // 성공 시 204 반환
+    }
+
+    @GetMapping("/{adminId}")
+    public ResponseEntity<?> validatePassword(@PathVariable(name = "adminId") Long adminId,
+                                                   @RequestBody Map<String, String> request) {
+        String password = request.get("password");
+        adminService.validatePassword(adminId, password);
+        return new ResponseEntity<>("ok", HttpStatus.OK);
     }
 
     @PostMapping("/{adminId}")

--- a/backend/src/main/java/org/example/backend/users/domain/entity/Users.java
+++ b/backend/src/main/java/org/example/backend/users/domain/entity/Users.java
@@ -12,6 +12,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.example.backend.users.exception.admin.AdminException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Entity
 @Getter
@@ -60,5 +62,12 @@ public class Users {
 
     public boolean isEqualEmail(String email) {
         return this.email.equals(email);
+    }
+
+    public boolean matchPassword(String password, PasswordEncoder bCryptPasswordEncoder) {
+        if (!bCryptPasswordEncoder.matches(password, this.password)) {
+            return false;
+        }
+        return true;
     }
 }

--- a/backend/src/main/java/org/example/backend/users/service/AdminService.java
+++ b/backend/src/main/java/org/example/backend/users/service/AdminService.java
@@ -2,6 +2,7 @@ package org.example.backend.users.service;
 
 import static org.example.backend.users.exception.admin.AdminExceptionType.ALREADY_EXIST_LOGIN_ID;
 import static org.example.backend.users.exception.admin.AdminExceptionType.INVALID_ACCESS_TOKEN;
+import static org.example.backend.users.exception.admin.AdminExceptionType.NOT_VALID_PASSWORD;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -72,6 +73,14 @@ public class AdminService {
         return AdminResDto.of(admin);
     }
 
+
+    public void validatePassword(Long adminId, String password) {
+        Users admin = getAdminById(adminId);
+        boolean matched = admin.matchPassword(password, bCryptPasswordEncoder);
+        if (!matched) {
+            throw new AdminException(NOT_VALID_PASSWORD);
+        }
+    }
     public Users getAdminById(Long id) {
         return usersRepository.findById(id)
                 .orElseThrow(() -> new AdminException(INVALID_ACCESS_TOKEN));


### PR DESCRIPTION
- [X] 💯 테스트는 잘 통과했나요?
- [X] 🏗️ 빌드는 성공했나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?

## 작업 내용

비밀번호 유효 검사 기능 구현

## 스크린샷

### 포스트맨 테스트 결과
<img width="657" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/b6925b57-39ae-4a7e-b93e-7d2f9a534764" />

^ 유효하지 않는 비밀번호의 경우


</br>

<img width="649" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/766f41b2-5082-45ad-a501-625432244cf3" />

^ 유효한 비밀번호의 경우

## 주의사항

Closes #340 