### PR TITLE
[BE] 관리자 계정만 뉴스, 공지사항, 세미나, 논문 생성/수정/삭제 권한 허용

### DIFF
--- a/backend/src/main/java/org/example/backend/global/config/auth/SecurityConfig.java
+++ b/backend/src/main/java/org/example/backend/global/config/auth/SecurityConfig.java
@@ -10,6 +10,7 @@ import org.example.backend.jwt.LoginFilter;
 import org.example.backend.jwt.exception.JwtExceptionFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -75,6 +76,38 @@ public class SecurityConfig {
                 .formLogin(formLogin -> formLogin.disable())
                 .httpBasic(httpBasic -> httpBasic.disable())
                 .authorizeHttpRequests(auth -> auth
+                        // 관리자 전용: 뉴스 생성, 수정, 삭제 엔드포인트
+                        .requestMatchers(HttpMethod.POST, "/api/news").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.POST, "/api/news/*").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.DELETE, "/api/news/*").hasRole("ADMIN")
+
+                        // 조회 관련 엔드포인트는 모두에게 허용
+                        .requestMatchers(HttpMethod.GET, "/api/news/**").permitAll()
+
+                        // 관리자 전용: 공지사항 생성, 수정, 삭제 엔드포인트
+                        .requestMatchers(HttpMethod.POST, "/api/board").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.POST, "/api/board/*").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.DELETE, "/api/board/*").hasRole("ADMIN")
+
+                        // 조회 관련 엔드포인트는 모두에게 허용
+                        .requestMatchers(HttpMethod.GET, "/api/board/**").permitAll()
+
+                        // 관리자 전용: 세미나 생성, 수정, 삭제 엔드포인트
+                        .requestMatchers(HttpMethod.POST, "/api/seminar").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.POST, "/api/seminar/*").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.DELETE, "/api/seminar/*").hasRole("ADMIN")
+
+                        // 조회 관련 엔드포인트는 모두에게 허용
+                        .requestMatchers(HttpMethod.GET, "/api/seminar/**").permitAll()
+
+                        // 관리자 전용: 논문 생성, 수정, 삭제 엔드포인트
+                        .requestMatchers(HttpMethod.POST, "/api/thesis").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.POST, "/api/thesis/*").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.DELETE, "/api/thesis/*").hasRole("ADMIN")
+
+                        // 조회 관련 엔드포인트는 모두에게 허용
+                        .requestMatchers(HttpMethod.GET, "/api/thesis/**").permitAll()
+
                         .requestMatchers("/api/admin/login", "/api/member/login",
                                 "/", "/api/**", "/v3/api-docs/**", "/swagger-ui/**", // TODO: 배포 전에  "/api/**" 삭제 필요
                                 "/swagger-resources/**", "/swagger*/**", "/uploads/**")

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -33,10 +33,7 @@ VALUES (1, '바이오융합공학과',
 -- users 더미 데이터
 INSERT INTO users (users_id, login_id, password, username, email, phoneN, role)
 VALUES (1, 'admin', '$2a$10$FKHTTHcEkAZZGW9XqGtPfOx.apKljbCLvYESM05YbLWzDynnacLPO', '관리자', 'admin@example.com',
-        '010-1234-5678', 'ROLE_ADMIN'),
-       (2, 'member', '$2a$10$FKHTTHcEkAZZGW9XqGtPfOx.apKljbCLvYESM05YbLWzDynnacLPO', '멤버', 'member@example.com',
-        '010-1111-2222', 'ROLE_MEMBER');
-
+        '010-1234-5678', 'ROLE_ADMIN');
 
 -- Professor 더미 데이터 (10개)
 INSERT INTO professor (professor_id, name, major, phone, email, position, homepage, lab, profile_image)

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -32,8 +32,10 @@ VALUES (1, '바이오융합공학과',
 
 -- users 더미 데이터
 INSERT INTO users (users_id, login_id, password, username, email, phoneN, role)
-VALUES (1, 'admin', '$2a$10$FKHTTHcEkAZZGW9XqGtPfOx.apKljbCLvYESM05YbLWzDynnacLPO', '관리자', 'admin@example.com','010-1234-5678', 'ROLE_ADMIN'),
-        (2, 'member', '$2a$10$FKHTTHcEkAZZGW9XqGtPfOx.apKljbCLvYESM05YbLWzDynnacLPO', '멤버', 'member@example.com', '010-1111-2222', 'ROLE_MEMBER');
+VALUES (1, 'admin', '$2a$10$FKHTTHcEkAZZGW9XqGtPfOx.apKljbCLvYESM05YbLWzDynnacLPO', '관리자', 'admin@example.com',
+        '010-1234-5678', 'ROLE_ADMIN'),
+       (2, 'member', '$2a$10$FKHTTHcEkAZZGW9XqGtPfOx.apKljbCLvYESM05YbLWzDynnacLPO', '멤버', 'member@example.com',
+        '010-1111-2222', 'ROLE_MEMBER');
 
 
 -- Professor 더미 데이터 (10개)


### PR DESCRIPTION
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
결과적으로, AOP를 이용하는 @PreAuthorize의 경우, 새로운 프록시 객체가 컨트롤러를 감싸게 되어 보안 검증 로직이 수행되기 때문에, 
프록시 객체 생성이 부담으로 다가와 SecurityConfig에서 총괄하여 관리하는 전략을 선택했습니다.

### 1. SecurityConfig에서 URL 기반 접근 제어 (.hasRole(“ADMIN”))
동작 원리: Http 요청을 가로채는 Security Filter에  옵션을 주는 방법
장점:

- 중앙 집중적 관리: 모든 접근 제어 정책이 한 곳(보통 SecurityConfig)에 집중
- 일관성: 모든 엔드포인트에 대해 일관된 보안 규칙을 적용
- 변경 용이성: 보안 정책이 변경될 때, SecurityConfig 하나만 수정하면 되므로 전체 시스템에 빠르게 반영

단점:

- 세밀한 제어 어려움
- 코드와의 분리: 보안 규칙이 컨트롤러 코드와 분리되어 있음
<img width="700" alt="image" src="https://github.com/user-attachments/assets/e4f7f04a-5665-4c9f-bdf2-7cf99fa0e2c9" />

### 2. 메소드 레벨 보안 (@PreAuthorize(“hasRole(‘ADMIN’)”) 이용)
동작 원리: 메소드 수준의 보안을 AOP를 통해 구현
장점:

- 세밀한 제어
- 코드와의 응집도: 메소드 선언 바로 위에 보안 어노테이션이 있어, 이 API가 어떤 권한을 필요로 하는지 명확
- 복잡한 조건 적용 가능

단점:

- 분산 관리: 여러 컨트롤러에 보안 어노테이션이 분산되어 있으면, 전체적인 보안 정책을 한눈에 파악하거나 일괄 변경하기 어려울 수 있음.
- 중복 가능성: 여러 엔드포인트에서 동일한 보안 조건이 반복될 경우, 관리 측면에서 중복 코드 문제가 발생
<img width="700" alt="image" src="https://github.com/user-attachments/assets/ad9e5b7f-405e-43cf-bb84-126026fca261" />

## 스크린샷
<img width="700" alt="image" src="https://github.com/user-attachments/assets/b8fa1abc-bb82-478a-9621-ba9ce79c2e53" />

```java
.requestMatchers(HttpMethod.POST, "/api/news").hasRole("ADMIN")
```

위의 옵션을 주면 일반 사용자가 뉴스를 생성할 수 없다 (Member)

<img width="700" alt="image" src="https://github.com/user-attachments/assets/3a9b7821-8f26-440f-a6dd-6e2243cc1f4f" />

## 주의사항

Closes #357 