### PR TITLE
[BE][FEAT] 관리자 이메일로 임시 비밀번호 발송

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -67,7 +67,7 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
     jvmArgs '-XX:+EnableDynamicAgentLoading'
-    enabled = false
+    enabled = true
 }
 
 tasks.withType(JavaCompile) {

--- a/backend/src/main/java/org/example/backend/global/config/auth/SecurityConfig.java
+++ b/backend/src/main/java/org/example/backend/global/config/auth/SecurityConfig.java
@@ -10,6 +10,7 @@ import org.example.backend.jwt.LoginFilter;
 import org.example.backend.jwt.exception.JwtExceptionFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -75,6 +76,38 @@ public class SecurityConfig {
                 .formLogin(formLogin -> formLogin.disable())
                 .httpBasic(httpBasic -> httpBasic.disable())
                 .authorizeHttpRequests(auth -> auth
+                        // 관리자 전용: 뉴스 생성, 수정, 삭제 엔드포인트
+                        .requestMatchers(HttpMethod.POST, "/api/news").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.POST, "/api/news/*").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.DELETE, "/api/news/*").hasRole("ADMIN")
+
+                        // 조회 관련 엔드포인트는 모두에게 허용
+                        .requestMatchers(HttpMethod.GET, "/api/news/**").permitAll()
+
+                        // 관리자 전용: 공지사항 생성, 수정, 삭제 엔드포인트
+                        .requestMatchers(HttpMethod.POST, "/api/board").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.POST, "/api/board/*").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.DELETE, "/api/board/*").hasRole("ADMIN")
+
+                        // 조회 관련 엔드포인트는 모두에게 허용
+                        .requestMatchers(HttpMethod.GET, "/api/board/**").permitAll()
+
+                        // 관리자 전용: 세미나 생성, 수정, 삭제 엔드포인트
+                        .requestMatchers(HttpMethod.POST, "/api/seminar").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.POST, "/api/seminar/*").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.DELETE, "/api/seminar/*").hasRole("ADMIN")
+
+                        // 조회 관련 엔드포인트는 모두에게 허용
+                        .requestMatchers(HttpMethod.GET, "/api/seminar/**").permitAll()
+
+                        // 관리자 전용: 논문 생성, 수정, 삭제 엔드포인트
+                        .requestMatchers(HttpMethod.POST, "/api/thesis").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.POST, "/api/thesis/*").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.DELETE, "/api/thesis/*").hasRole("ADMIN")
+
+                        // 조회 관련 엔드포인트는 모두에게 허용
+                        .requestMatchers(HttpMethod.GET, "/api/thesis/**").permitAll()
+
                         .requestMatchers("/api/admin/login", "/api/member/login",
                                 "/", "/api/**", "/v3/api-docs/**", "/swagger-ui/**", // TODO: 배포 전에  "/api/**" 삭제 필요
                                 "/swagger-resources/**", "/swagger*/**", "/uploads/**")

--- a/backend/src/main/java/org/example/backend/users/controller/admin/AdminController.java
+++ b/backend/src/main/java/org/example/backend/users/controller/admin/AdminController.java
@@ -2,11 +2,14 @@ package org.example.backend.users.controller.admin;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
+import jakarta.transaction.Transactional;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.backend.users.domain.dto.LoginReqDto;
 import org.example.backend.users.domain.dto.admin.AdminResDto;
+import org.example.backend.users.domain.dto.admin.mail.MailReqDto;
+import org.example.backend.users.domain.dto.admin.mail.MailResDto;
 import org.example.backend.users.domain.entity.CustomUserDetails;
 import org.example.backend.users.domain.entity.Users;
 import org.example.backend.users.service.AdminService;
@@ -60,6 +63,13 @@ public class AdminController {
         String password = request.get("password");
         AdminResDto adminResDto = adminService.updateAdminPassword(adminId, password);
         return new ResponseEntity<>(adminResDto, HttpStatus.OK);
+    }
+
+    @PostMapping("/sendEmail")
+    public ResponseEntity<Void> sendEmail(@RequestBody MailReqDto mailReqDto) {
+        MailResDto dto = adminService.createTmpPasswordMail(mailReqDto);
+        adminService.mailSend(dto);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     @PostMapping("/test")

--- a/backend/src/main/java/org/example/backend/users/exception/admin/AdminExceptionType.java
+++ b/backend/src/main/java/org/example/backend/users/exception/admin/AdminExceptionType.java
@@ -8,6 +8,7 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @RequiredArgsConstructor
 public enum AdminExceptionType implements BaseExceptionType {
+    NOT_FOUND_ADMIN(NOT_FOUND, "계정을 찾을 수 없습니다"),
     ALREADY_EXIST_LOGIN_ID(NOT_FOUND, "이미 존재하는 로그인 ID입니다"),
     NOT_VALID_PASSWORD(NOT_FOUND, "비밀번호가 유효하지 않습니다"),
     INVALID_ACCESS_TOKEN(NOT_FOUND, "토큰이 유효하지 않습니다"),

--- a/backend/src/main/java/org/example/backend/users/exception/member/MemberExceptionType.java
+++ b/backend/src/main/java/org/example/backend/users/exception/member/MemberExceptionType.java
@@ -6,7 +6,9 @@ import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
 public enum MemberExceptionType implements BaseExceptionType {
-    DEPARTMENT_NOT_BIO(HttpStatus.BAD_REQUEST, "바이오융합공학과 소속이 아닙니다.");
+    DEPARTMENT_NOT_BIO(HttpStatus.BAD_REQUEST, "바이오융합공학과 소속이 아닙니다."),
+    INVALID_ID_OR_PASSWORD(HttpStatus.UNAUTHORIZED, "유효하지 않는 아이디 또는 비밀번호입니다."),
+    SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final String errorMessage;

--- a/backend/src/main/java/org/example/backend/users/repository/UsersRepository.java
+++ b/backend/src/main/java/org/example/backend/users/repository/UsersRepository.java
@@ -5,11 +5,7 @@ import org.example.backend.users.domain.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UsersRepository extends JpaRepository<Users, Long> {
-    Users findByUsername(String username);
-
     Optional<Users> findByLoginId(String loginId);
-
-    Boolean existsByUsername(String username);
 
     Boolean existsByLoginId(String loginId);
 }

--- a/backend/src/main/java/org/example/backend/users/service/AdminService.java
+++ b/backend/src/main/java/org/example/backend/users/service/AdminService.java
@@ -2,17 +2,26 @@ package org.example.backend.users.service;
 
 import static org.example.backend.users.exception.admin.AdminExceptionType.ALREADY_EXIST_LOGIN_ID;
 import static org.example.backend.users.exception.admin.AdminExceptionType.INVALID_ACCESS_TOKEN;
+import static org.example.backend.users.exception.admin.AdminExceptionType.NOT_FOUND_ADMIN;
+import static org.example.backend.users.exception.admin.AdminExceptionType.NOT_FOUND_MAIL_RECEIVER;
+import static org.example.backend.users.exception.admin.AdminExceptionType.NOT_MATCH_EMAIL;
 import static org.example.backend.users.exception.admin.AdminExceptionType.NOT_VALID_PASSWORD;
 
+import java.security.SecureRandom;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.backend.users.domain.dto.LoginReqDto;
 import org.example.backend.users.domain.dto.admin.AccessTokenReq;
+import org.example.backend.users.domain.dto.admin.AdminReqDto;
 import org.example.backend.users.domain.dto.admin.AdminResDto;
+import org.example.backend.users.domain.dto.admin.mail.MailReqDto;
+import org.example.backend.users.domain.dto.admin.mail.MailResDto;
 import org.example.backend.users.domain.entity.Role;
 import org.example.backend.users.domain.entity.Users;
 import org.example.backend.users.exception.admin.AdminException;
 import org.example.backend.users.repository.UsersRepository;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +35,8 @@ public class AdminService {
     private final UsersRepository usersRepository;
     private final PasswordEncoder bCryptPasswordEncoder;
     private static final String BEARER_TYPE = "Bearer";
+    private static final String DEFAULT_FROM_EMAIL = "zkffl0@naver.com";
+    private final JavaMailSender mailSender;
 
     @Transactional(readOnly = false)
     public void joinProcess(LoginReqDto joinDTO) {
@@ -84,5 +95,68 @@ public class AdminService {
     public Users getAdminById(Long id) {
         return usersRepository.findById(id)
                 .orElseThrow(() -> new AdminException(INVALID_ACCESS_TOKEN));
+    }
+
+    @Transactional
+    public MailResDto createTmpPasswordMail(MailReqDto mailReqDto) {
+        Users admin = findAdminByLoginId(mailReqDto.getLoginId());
+
+        if (!admin.isEqualEmail(mailReqDto.getEmail())) {
+            throw new AdminException(NOT_MATCH_EMAIL);
+        }
+
+        String tmpPassword = getTmpPassword();
+        updatePassword(admin, tmpPassword);
+
+        MailResDto dto = new MailResDto();
+        dto.setAddress(mailReqDto.getEmail());
+        dto.setTitle("임시 비밀번호 발송");
+        dto.setMessage("임시 비밀번호는 " + tmpPassword + " 입니다.");
+
+        return dto;
+    }
+
+    private Users findAdminByLoginId(String loginId) {
+        return usersRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new AdminException(NOT_FOUND_ADMIN));
+    }
+
+    private String getTmpPassword() {
+        char[] charSet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ".toCharArray();
+        SecureRandom random = new SecureRandom();
+        StringBuilder str = new StringBuilder();
+
+        for (int i = 0; i < 8; i++) {
+            int idx = random.nextInt(charSet.length);
+            str.append(charSet[idx]);
+        }
+
+        return str.toString();
+    }
+
+    private void updatePassword(Users admin, String tmpPassword) {
+        admin.updatePassword(bCryptPasswordEncoder.encode(tmpPassword));
+        usersRepository.save(admin);
+    }
+
+    public void mailSend(MailResDto dto) {
+        if (dto.getAddress() == null || dto.getAddress().isBlank()) {
+            log.error("메일 발송 실패: 이메일 주소가 비어 있습니다.");
+            throw new AdminException(NOT_FOUND_MAIL_RECEIVER);
+        }
+
+        try {
+            SimpleMailMessage message = new SimpleMailMessage();
+            message.setTo(dto.getAddress());
+            message.setSubject(dto.getTitle());
+            message.setText(dto.getMessage());
+            message.setFrom(DEFAULT_FROM_EMAIL);
+            message.setReplyTo(DEFAULT_FROM_EMAIL);
+
+            mailSender.send(message);
+        } catch (Exception e) {
+            log.error("메일 발송 중 오류 발생: {}", e.getMessage(), e);
+            throw new RuntimeException("메일 발송에 실패했습니다.", e);
+        }
     }
 }

--- a/backend/src/main/java/org/example/backend/users/service/MemberService.java
+++ b/backend/src/main/java/org/example/backend/users/service/MemberService.java
@@ -1,6 +1,8 @@
 package org.example.backend.users.service;
 
 import static org.example.backend.users.exception.member.MemberExceptionType.DEPARTMENT_NOT_BIO;
+import static org.example.backend.users.exception.member.MemberExceptionType.INVALID_ID_OR_PASSWORD;
+import static org.example.backend.users.exception.member.MemberExceptionType.SERVER_ERROR;
 
 import java.io.IOException;
 import java.util.Map;
@@ -66,7 +68,7 @@ public class MemberService {
             Connection.Response response = executeLoginRequest(dto);
 
             if (response.statusCode() != 200) {
-                throw new RuntimeException("서버 오류가 발생했습니다: HTTP " + response.statusCode());
+                throw new MemberException(SERVER_ERROR);
             }
 
             return parseUserProfile(response.parse());
@@ -86,7 +88,7 @@ public class MemberService {
     private SjUserProfile parseUserProfile(Document document) throws AuthenticationException {
         Element userInfo = document.selectFirst("div.user-info-picture");
         if (userInfo == null) {
-            throw new RuntimeException(AUTH_FAILED);
+            throw new MemberException(INVALID_ID_OR_PASSWORD);
         }
 
         Element nameElement = document.selectFirst("h4");

--- a/backend/src/main/java/org/example/backend/users/service/MemberService.java
+++ b/backend/src/main/java/org/example/backend/users/service/MemberService.java
@@ -3,11 +3,7 @@ package org.example.backend.users.service;
 import static org.example.backend.users.exception.member.MemberExceptionType.DEPARTMENT_NOT_BIO;
 
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Iterator;
 import java.util.Map;
-import java.util.Optional;
-import jdk.jshell.spi.ExecutionControl.UserException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.backend.blacklist.dto.BlackListTokenDto;
@@ -15,24 +11,15 @@ import org.example.backend.blacklist.service.JwtBlacklistService;
 import org.example.backend.jwt.JWTUtil;
 import org.example.backend.users.domain.dto.LoginReqDto;
 import org.example.backend.users.domain.dto.member.SjUserProfile;
-import org.example.backend.users.domain.entity.CustomUserDetails;
 import org.example.backend.users.domain.entity.Role;
-import org.example.backend.users.domain.entity.Users;
 import org.example.backend.users.exception.member.MemberException;
-import org.example.backend.users.repository.UsersRepository;
 import org.jsoup.Connection;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 
@@ -44,33 +31,17 @@ public class MemberService {
     private final String AUTH_FAILED = "인증에 실패하였습니다.";
     private final String USER_INFO_MISSING = "사용자 정보를 찾을 수 없습니다.";
 
-    private final AuthenticationManager authenticationManager;
     private final JWTUtil jwtUtil;
-    private final UsersRepository usersRepository;
-    private final PasswordEncoder passwordEncoder;
     private final JwtBlacklistService jwtBlacklistService;
 
     public ResponseEntity<?> authenticateAndGenerateToken(LoginReqDto dto) {
         try {
-            Users user = usersRepository.findByLoginId(dto.getLoginId())
-                    .orElseGet(() -> authenticateAndSaveUser(dto));
+            authenticateAndValidateMajor(dto);
 
-            Authentication authentication = authenticationManager.authenticate(
-                    new UsernamePasswordAuthenticationToken(user.getLoginId(), dto.getPassword())
-            );
+            String role = "ROLE_MEMBER";
 
-            SecurityContextHolder.getContext().setAuthentication(authentication);
-
-            CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
-            String loginId = customUserDetails.getUsername();
-
-            Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
-            Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
-            GrantedAuthority auth = iterator.next();
-            String role = auth.getAuthority();
-
-            String accessToken = jwtUtil.createJwt(loginId, Role.valueOf(role), 1800 * 1000L);
-            String refreshToken = jwtUtil.createJwt(loginId, Role.valueOf(role), 60 * 60 * 24 * 30 * 1000L);
+            String accessToken = jwtUtil.createJwt(dto.getLoginId(), Role.valueOf(role), 1800 * 1000L);
+            String refreshToken = jwtUtil.createJwt(dto.getLoginId(), Role.valueOf(role), 60 * 60 * 24 * 30 * 1000L);
 
             return ResponseEntity.ok().body(Map.of(
                     "accessToken", accessToken,
@@ -81,33 +52,13 @@ public class MemberService {
         }
     }
 
-    public Users authenticateAndSaveUser(LoginReqDto dto) throws AuthenticationException {
+    public void authenticateAndValidateMajor(LoginReqDto dto) throws AuthenticationException {
         SjUserProfile profile = authenticate(dto);
-
-        Optional<Users> existingUser = usersRepository.findByLoginId(dto.getLoginId());
-
-        if (existingUser.isPresent()) {
-            return existingUser.get();
-        }
 
         // 바이오융합공학과(, 컴퓨터공학과, 양자원자력공학과) 학생만 가입 가능
         if (!profile.getMajor().equals("바이오융합공학과") && !profile.getMajor().equals("컴퓨터공학과")) {
             throw new MemberException(DEPARTMENT_NOT_BIO);
         }
-
-        Users newUser = Users.builder()
-                .loginId(dto.getLoginId())
-                .password(passwordEncoder.encode(dto.getPassword()))
-                .username(profile.getName())
-                .email(null)
-                .phoneN(null)
-                .department(profile.getMajor())
-                .role(Role.ROLE_MEMBER)
-                .build();
-
-        usersRepository.save(newUser);
-        return newUser;
-
     }
 
     public SjUserProfile authenticate(LoginReqDto dto) throws AuthenticationException {

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -12,9 +12,8 @@ VALUES (1, '바이오융합공학과',
 
 -- users 더미 데이터
 INSERT INTO users (users_id, login_id, password, username, email, phoneN, role)
-VALUES (1, 'admin', '$2a$10$FKHTTHcEkAZZGW9XqGtPfOx.apKljbCLvYESM05YbLWzDynnacLPO', '관리자', 'admin@example.com','010-1234-5678', 'ROLE_ADMIN'),
-        (2, 'member', '$2a$10$FKHTTHcEkAZZGW9XqGtPfOx.apKljbCLvYESM05YbLWzDynnacLPO', '멤버', 'member@example.com', '010-1111-2222', 'ROLE_MEMBER');
-
+VALUES (1, 'admin', '$2a$10$FKHTTHcEkAZZGW9XqGtPfOx.apKljbCLvYESM05YbLWzDynnacLPO', '관리자', 'admin@example.com',
+        '010-1234-5678', 'ROLE_ADMIN');
 
 -- Professor 더미 데이터 (10개)
 INSERT INTO professor (professor_id, name, major, phone, email, position, homepage, lab, profile_image)


### PR DESCRIPTION
- [X] 💯 테스트는 잘 통과했나요?
- [X] 🏗️ 빌드는 성공했나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?

## 작업 내용

관리자 이메일로 임시 비밀번호 발송

## 스크린샷

<img width="288" alt="image" src="https://github.com/user-attachments/assets/c6fc69fb-b2a1-4329-9ef9-e711eae8dbe2" />


## 주의사항
테스트 해보고 싶다면 

1. yml 파일에 

<img width="373" alt="image" src="https://github.com/user-attachments/assets/db8bd254-305d-4ea0-af35-dc3b35950149" />

username에는 본인 이메일
password는 이메일의 비밀번호

2. adminService

상단에 DEFAULT_FROM_EMAIL 를 본인 이메일로 수정

하시면 테스트 해보실 수 있습니다

Closes #144 