### PR TITLE
[BE][FIX] 논문 엔티티 교수 필드 null 허용

### DIFF
--- a/backend/src/main/java/org/example/backend/thesis/domain/entity/Thesis.java
+++ b/backend/src/main/java/org/example/backend/thesis/domain/entity/Thesis.java
@@ -52,7 +52,7 @@ public class Thesis {
     private String issn;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "professor_id", nullable = false)
+    @JoinColumn(name = "professor_id", nullable = true)
     private Professor professor;
 
     @Builder

--- a/backend/src/main/java/org/example/backend/thesis/exception/ThesisExceptionType.java
+++ b/backend/src/main/java/org/example/backend/thesis/exception/ThesisExceptionType.java
@@ -10,8 +10,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ThesisExceptionType implements BaseExceptionType {
 
-    NOT_FOUND_THESIS(NOT_FOUND, "논문를 찾을 수 없습니다"),
-
+    NOT_FOUND_THESIS(NOT_FOUND, "논문을 찾을 수 없습니다"),
     REQUIRED_AUTHOR(BAD_REQUEST, "저자는 필수 입력값입니다."),
     REQUIRED_TITLE(BAD_REQUEST, "제목은 필수 입력값입니다");
 

--- a/backend/src/main/java/org/example/backend/thesis/service/ThesisService.java
+++ b/backend/src/main/java/org/example/backend/thesis/service/ThesisService.java
@@ -1,10 +1,12 @@
 package org.example.backend.thesis.service;
 
+import static org.example.backend.professor.exception.ProfessorExceptionType.NOT_FOUND_PROFESSOR;
 import static org.example.backend.thesis.exception.ThesisExceptionType.NOT_FOUND_THESIS;
 
 import lombok.RequiredArgsConstructor;
 import org.example.backend.global.config.file.LocalFileUploader;
 import org.example.backend.professor.domain.entity.Professor;
+import org.example.backend.professor.exception.ProfessorException;
 import org.example.backend.professor.repository.ProfessorRepository;
 import org.example.backend.thesis.domain.dto.ThesisReqDto;
 import org.example.backend.thesis.domain.dto.ThesisResDto;
@@ -48,7 +50,7 @@ public class ThesisService {
 
     private Professor findProfessorById(Long professorId) {
         return professorRepository.findById(professorId)
-                .orElseThrow(() -> new ThesisException(NOT_FOUND_THESIS));
+                .orElseThrow(() -> new ProfessorException(NOT_FOUND_PROFESSOR));
     }
 
     public ThesisResDto getThesis(Long thesisId) {

--- a/backend/src/main/java/org/example/backend/thesis/service/ThesisService.java
+++ b/backend/src/main/java/org/example/backend/thesis/service/ThesisService.java
@@ -1,12 +1,11 @@
 package org.example.backend.thesis.service;
 
-import static org.example.backend.professor.exception.ProfessorExceptionType.NOT_FOUND_PROFESSOR;
 import static org.example.backend.thesis.exception.ThesisExceptionType.NOT_FOUND_THESIS;
 
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.example.backend.global.config.file.LocalFileUploader;
 import org.example.backend.professor.domain.entity.Professor;
-import org.example.backend.professor.exception.ProfessorException;
 import org.example.backend.professor.repository.ProfessorRepository;
 import org.example.backend.thesis.domain.dto.ThesisReqDto;
 import org.example.backend.thesis.domain.dto.ThesisResDto;
@@ -49,8 +48,7 @@ public class ThesisService {
 
 
     private Professor findProfessorById(Long professorId) {
-        return professorRepository.findById(professorId)
-                .orElseThrow(() -> new ProfessorException(NOT_FOUND_PROFESSOR));
+        return professorRepository.findById(professorId).orElse(null);
     }
 
     public ThesisResDto getThesis(Long thesisId) {


### PR DESCRIPTION
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
논문 생성 시 교수가 아니라 학사, 석사, 박사 저자도 허용하도록 교수 엔티티가 조회되지 않아도 생성이 가능하게 로직을 변경했음.

## 스크린샷
<img width="700" alt="스크린샷 2025-02-15 오후 5 42 07" src="https://github.com/user-attachments/assets/198ad41e-60d3-4fdb-8337-e3c04679d353" />
<img width="700" alt="스크린샷 2025-02-15 오후 5 41 50" src="https://github.com/user-attachments/assets/cef1ea48-09cf-4d3e-b4b4-9caa4c69fcdb" />


## 주의사항

Closes #{이슈 번호}