### PR TITLE
#389 fix: CI/CD 배포 오류 해결을 위한 빌드 스크립트 수정 2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,11 +46,11 @@ jobs:
           chmod +x ./gradlew
           ./gradlew build -x test
 
-      # Node.js 설정 (프론트엔드 빌드를 위한 Node.js 22 설치)
+      # Node.js 설정 (프론트엔드 빌드를 위한 Node.js 설치)
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '22'
+          node-version: '20'  # 더 안정적인 LTS 버전으로 변경
 
       # 프론트엔드 빌드 - 수정된 부분
       - name: Install and Build Frontend

--- a/frontend/craco.config.js
+++ b/frontend/craco.config.js
@@ -4,6 +4,10 @@ module.exports = {
       resolve: {
         fallback: {
           crypto: require.resolve('crypto-browserify'),
+          stream: require.resolve('stream-browserify'),
+          buffer: require.resolve('buffer/'),
+          util: require.resolve('util/'),
+          assert: require.resolve('assert/'),
         },
       },
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,7 +57,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "npx craco build",
+    "build": "craco build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
@@ -83,10 +83,14 @@
     "@craco/craco": "^7.1.0",
     "@types/dompurify": "^3.0.5",
     "@types/node": "^22.7.0",
+    "assert": "^2.0.0",
+    "buffer": "^6.0.3",
     "crypto-browserify": "^3.12.1",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-react": "^7.36.1",
-    "prettier": "^3.3.3"
+    "prettier": "^3.3.3",
+    "stream-browserify": "^3.0.0",
+    "util": "^0.12.5"
   }
 }


### PR DESCRIPTION
main.yml 파일에서의 수정사항:

craco.config.js 생성 부분에서 fall***를 fallback으로 수정했습니다.
Node.js 버전을 22에서 더 안정적인 20 LTS 버전으로 변경했습니다.


package.json 파일에서의 수정사항:

빌드 스크립트를 npx craco build에서 craco build로 변경했습니다.
필요한 폴리필 패키지들을 devDependencies에 추가했습니다:

assert
buffer
stream-browserify
util




craco.config.js 파일:

이 파일을 미리 프로젝트에 추가해 GitHub Actions에서 생성하는 대신 이미 존재하게 할 수 있습니다.
webpack 설정에서 fallback 옵션을 올바르게 지정하여 브라우저 환경에서 Node.js 모듈을 사용할 수 있도록 합니다.