### PR TITLE
#389 fix: CI/CD 배포 픽스

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,47 +55,42 @@ jobs:
       - name: Install and Build Frontend
         env:
           CI: false
-          NODE_ENV: production
           DISABLE_ESLINT_PLUGIN: true
         run: |
           cd frontend
-          npm install
+          # devDependencies까지 설치하도록 옵션 추가
+          npm install --production=false
           
           # 폴리필 및 react-app-rewired 설치
           npm install --save-dev react-app-rewired crypto-browserify stream-browserify buffer assert util
           
           # config-overrides.js 파일 생성
           echo "const webpack = require('webpack');
-          
-          module.exports = function override(config) {
+  
+            module.exports = function override(config) {
             // 폴리필 설정
             config.resolve.fallback = {
-              ...config.resolve.fallback,
-              crypto: require.resolve('crypto-browserify'),
-              stream: require.resolve('stream-browserify'),
-              buffer: require.resolve('buffer'),
-              util: require.resolve('util'),
-              assert: require.resolve('assert')
-            };
+            ...config.resolve.fallback,
+          crypto: require.resolve('crypto-browserify'),
+          stream: require.resolve('stream-browserify'),
+          buffer: require.resolve('buffer'),
+          util: require.resolve('util'),
+          assert: require.resolve('assert')
+          };
           
             // Buffer 전역 객체 제공
             config.plugins = [
-              ...config.plugins,
-              new webpack.ProvidePlugin({
-                Buffer: ['buffer', 'Buffer'],
-              }),
+            ...config.plugins,
+            new webpack.ProvidePlugin({
+          Buffer: ['buffer', 'Buffer'],
+          }),
             ];
-          
+
             return config;
           };" > config-overrides.js
-          
-          # package.json 스크립트 수정
-          node -e "
-            const fs = require('fs');
-            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-            pkg.scripts.build = 'react-app-rewired build';
-            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2));
-          "
+  
+          # package.json 스크립트 수정: 빌드 스크립트를 react-app-rewired build 로 변경
+          node -e "const fs = require('fs'); const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8')); pkg.scripts.build = 'react-app-rewired build'; fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2));"
           
           # 빌드 실행
           npx react-app-rewired build
@@ -112,10 +107,7 @@ jobs:
           
           # 프론트엔드 이미지 빌드 및 푸시
           cd ../frontend
-          docker build \
-            --build-arg REACT_APP_GOOGLE_MAPS_API_KEY="${{ secrets.REACT_APP_GOOGLE_MAPS_API_KEY }}" \
-            --build-arg REACT_APP_VIDEO_BASE_URL="${{ secrets.REACT_APP_VIDEO_BASE_URL }}" \
-            -t ${{ secrets.DOCKER_USERNAME }}/frontend:latest .
+          docker build --build-arg REACT_APP_GOOGLE_MAPS_API_KEY="${{ secrets.REACT_APP_GOOGLE_MAPS_API_KEY }}" --build-arg REACT_APP_VIDEO_BASE_URL="${{ secrets.REACT_APP_VIDEO_BASE_URL }}" -t ${{ secrets.DOCKER_USERNAME }}/frontend:latest .
           docker push ${{ secrets.DOCKER_USERNAME }}/frontend:latest
 
       # 서버에 docker-compose.yml 생성 및 실행
@@ -132,7 +124,6 @@ jobs:
             
             # GitHub Secrets에서 docker-compose.yml 생성
             echo "${{ secrets.DOCKER_COMPOSE_YML }}" > docker-compose.yml
-            
             
             # 기존 컨테이너 정리 및 새 배포 실행
             docker-compose down || true

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,4 +2,4 @@
 
 ![image](https://github.com/user-attachments/assets/fdd66cc3-a936-440d-bac3-2ebd96c1920c)
 
-5
+6


### PR DESCRIPTION
-  CI 빌드 환경에서 devDependencies도 설치하도록 NODE_ENV를 제거하거나 npm install --production=false(또는 --include=dev)를 사용

- 또는 빌드 시 필요한 라이브러리를 dependencies로 옮겨 devDependencies 없이도 빌드가 가능하도록 조정