### PR TITLE
[BE] 예약 서비스 동시성 문제 해결을 위한 비관적 락 적용

### DIFF
--- a/backend/src/main/java/org/example/backend/reservation/repository/ReservationRepository.java
+++ b/backend/src/main/java/org/example/backend/reservation/repository/ReservationRepository.java
@@ -26,11 +26,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     );
 
     @Query("SELECT r FROM Reservation r " +
-            "WHERE r.room.id = :seminarRoomId ")
-    List<Reservation> finaReservationsBySeminarRoom(
-            @Param("seminarRoomId")Long seminarRoomId);
-
-    @Query("SELECT r FROM Reservation r " +
             "WHERE r.room.id = :roomId " +
             "AND DATE_FORMAT(r.startTime, '%Y-%m') = :yearMonth " +
             "ORDER BY r.startTime")

--- a/backend/src/main/java/org/example/backend/reservation/repository/ReservationRepository.java
+++ b/backend/src/main/java/org/example/backend/reservation/repository/ReservationRepository.java
@@ -10,8 +10,8 @@ import org.springframework.data.repository.query.Param;
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
     @Query("SELECT COUNT(r) > 0 FROM Reservation r " +
             "WHERE r.room.id = :seminarRoomId " +
-            "AND r.startTime < :endTime " +
-            "AND r.endTime > :startTime")
+            "AND r.startTime <= :endTime " +
+            "AND r.endTime >= :startTime")
     boolean existsByTimePeriod(
             @Param("seminarRoomId") Long seminarRoomId,
             @Param("startTime") LocalDateTime startTime,

--- a/backend/src/main/java/org/example/backend/reservation/service/ReservationService.java
+++ b/backend/src/main/java/org/example/backend/reservation/service/ReservationService.java
@@ -79,7 +79,7 @@ public class ReservationService {
     }
 
     private Room getSeminarRoomById(Long seminarRoomId) {
-        return roomRepository.findById(seminarRoomId)
+        return roomRepository.findRoomForUpdate(seminarRoomId)
                 .orElseThrow(() -> new RoomException(NOT_FOUND_SEMINAR_ROOM));
     }
 
@@ -97,13 +97,13 @@ public class ReservationService {
         }
     }
     private void validateReservation(ReservationCreateDto reqDto, Long seminarRoomId) {
-        boolean hasReservationConflict = reservationRepository.existsByTimePeriod(
+        boolean hasReservation = reservationRepository.existsByTimePeriod(
                 seminarRoomId,
                 reqDto.getStartTime(),
                 reqDto.getEndTime()
         );
 
-        if (hasReservationConflict) {
+        if (hasReservation) {
             throw new ReservationException(EXIST_ALREADY_RESERVATION);
         }
     }

--- a/backend/src/main/java/org/example/backend/room/repository/RoomRepository.java
+++ b/backend/src/main/java/org/example/backend/room/repository/RoomRepository.java
@@ -1,7 +1,15 @@
 package org.example.backend.room.repository;
 
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
 import org.example.backend.room.domain.Room;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RoomRepository extends JpaRepository<Room, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT r FROM Room r WHERE r.id = :roomId")
+    Optional<Room> findRoomForUpdate(@Param("roomId") Long roomId);
 }


### PR DESCRIPTION
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

# 비관적 락 적용 이유

## 1. Redis를 통한 락 고려
- **분산 환경**에서 유용하게 사용할 수 있다는 장점이 있지만, 현재 서비스 규모·요건 상 **Redis 도입으로 얻을 이점**이 크지 않다고 판단했습니다.  
- Redis 인프라를 추가로 운영해야 하므로, **불필요한 리소스·자원 낭비**라고 생각해서 폐기했습니다.

## 2. 낙관적 락 고려
- 낙관적 락은 **충돌 발생 시 재시도 로직**이 필요한데 1인1예약인 상황에선 재시도 로직이 필요 없어보임  
- 사용자 경험 측면에서, 재시도가 발생하면 다시 예약을 시도하세요보다는 그냥 이미 예약됨이 나아보엿습니다.

## 3. 비관적 락 결정
- **단 하나의 회의실**에 **동일 시간대는 반드시 한 명만 예약**하도록 강제해야 합니다.  
- 성능보다 **중복 예약 방지**가 절대적으로 중요한 요구사항이라고 생각햇습니다.
- 동시에 여러 사용자가 예약을 시도하더라도, 락을 통해 **중복을 원천적으로 막아** 사용자 경험상 **재시도 로직**을 최소화하고자 합니다.
- 성능 저하가 일부 발생하더라도, **중복 방지**가 최우선이므로 비관적 락을 최종 선택했습니다.

@Lock(LockModeType.PESSIMISTIC_WRITE)를 사용하면, JPA는 해당 쿼리를 실행할 때 MySQL의 경우 SELECT … FOR UPDATE와 유사한 방식으로 동작하게 만들 수 있고, 지정된 행에 쓰기 잠금을 획득합니다. 잠금 효과를 제대로 적용시키기 위해 createReservation 메서드를 @Transactional처리 해주어 해당 메서드가 트랜잭션 내에서 실행되게 만들었습니다.

---
**결론**: Redis 락은 서비스 규모 상 과도한 자원 낭비로 보고 배제하였고, 낙관적 락은 재시도 로직으로 사용자 경험이 저해될 수 있어 **비관적 락**을 적용하였습니다.
## 스크린샷
<img width="875" alt="스크린샷 2025-02-26 오후 8 19 01" src="https://github.com/user-attachments/assets/1b96324e-35c9-447c-b661-94ea3741454e" />

## 참고
https://sabarada.tistory.com/175

## 주의사항
현재 제가 Room 전체에 거는 방식을 선택했는데 더 나은 방식이 있을까 의견듣고싶네요
Closes #231 