### PR TITLE
[FE] [FEAT] 메인페이지 스타일 수정

### DIFF
--- a/frontend/src/components/Banner/MainBanner/MainBanner.tsx
+++ b/frontend/src/components/Banner/MainBanner/MainBanner.tsx
@@ -65,7 +65,6 @@ const Title = styled.h1`
   text-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
   line-height: 1.1;
   letter-spacing: -0.02em;
-  text-transform: lowercase;
 
   @media (max-width: 768px) {
     font-size: 2.8rem;

--- a/frontend/src/components/Banner/VideoBanner/VideoSlide.tsx
+++ b/frontend/src/components/Banner/VideoBanner/VideoSlide.tsx
@@ -27,7 +27,6 @@ const Title = styled.h1`
   margin: 0;
   text-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
   line-height: 1.1;
-  text-transform: lowercase;
 
   @media (max-width: 768px) {
     font-size: 2.8rem;

--- a/frontend/src/components/Header/HeaderStyle.ts
+++ b/frontend/src/components/Header/HeaderStyle.ts
@@ -31,6 +31,11 @@ export const TopHeaderTitle = styled.div`
   font-size: 1.1rem;
   font-weight: 700;
   letter-spacing: 0.02em;
+
+  @media (max-width: 768px) {
+    font-size: 1rem;
+    font-weight: 600;
+  }
 `;
 
 export const TopNavList = styled.ul`
@@ -76,6 +81,10 @@ export const TopNavItem = styled.li`
     &:hover {
       opacity: 0.8;
       text-decoration: none;
+    }
+
+    @media (max-width: 768px) {
+      font-size: 0.875rem;
     }
   }
 

--- a/frontend/src/components/Header/HeaderStyle.ts
+++ b/frontend/src/components/Header/HeaderStyle.ts
@@ -28,8 +28,8 @@ export const TopHeaderInner = styled.div`
 
 export const TopHeaderTitle = styled.div`
   color: white;
-  font-size: 1rem;
-  font-weight: 600;
+  font-size: 1.1rem;
+  font-weight: 700;
   letter-spacing: 0.02em;
 `;
 
@@ -64,7 +64,7 @@ export const TopNavItem = styled.li`
   a {
     color: white;
     text-decoration: none;
-    font-size: 0.875rem;
+    font-size: 1rem;
     font-weight: 500;
     padding: 0;
     white-space: nowrap;

--- a/frontend/src/components/Header/Logo/LogoStyle.ts
+++ b/frontend/src/components/Header/Logo/LogoStyle.ts
@@ -41,11 +41,11 @@ export const LogoImage = styled.div`
   margin-bottom: 0;
 
   svg {
-    width: 52px;
+    width: 72px;
     height: auto;
 
     @media (max-width: 768px) {
-      width: 42px;
+      width: 57px;
     }
   }
 `;
@@ -54,20 +54,21 @@ export const LogoTitle = styled.div`
   display: flex;
   flex-direction: column;
   gap: 4px;
-  font-size: 1.25rem;
+  font-size: 1.6rem;
   font-weight: 800;
   letter-spacing: -0.02em;
   opacity: 0.95;
 `;
 
 export const Department = styled.span`
-  font-size: 1.25rem;
+  font-size: 1.6rem;
   font-weight: 800;
   letter-spacing: -0.02em;
   text-transform: none;
 
   @media (max-width: 768px) {
-    font-size: 1.1rem;
+    font-size: 1.5rem;
+    font-weight: 800;
   }
 `;
 
@@ -77,7 +78,7 @@ export const MobileLogoTitle = styled.div`
   transform: translateX(-50%);
   white-space: nowrap;
   font-size: 1.1rem;
-  font-weight: 600;
+  font-weight: 800;
   color: white;
   width: 100%;
   text-align: center;

--- a/frontend/src/components/Header/Navigation/NavItemStyle.ts
+++ b/frontend/src/components/Header/Navigation/NavItemStyle.ts
@@ -11,9 +11,9 @@ export const NavItemLink = styled(Link)<{ isActive?: boolean }>`
   display: inline-flex;
   align-items: center;
   height: 100%;
-  padding: 0 1.125rem; // TopNavItem과 동일한 간격을 위해 조정
+  padding: 0 1.6rem; // TopNavItem과 동일한 간격을 위해 조정
   color: white;
-  font-size: 1.1rem;
+  font-size: 1.6rem;
   font-weight: 600;
   white-space: nowrap;
   text-decoration: none;
@@ -52,8 +52,8 @@ export const SubMenuItem = styled(Link)`
   display: block;
   padding: 0.8rem 1.5rem;
   color: white;
-  font-size: 1rem;
-  font-weight: 500;
+  font-size: 1.1rem;
+  font-weight: 600;
   text-decoration: none;
   transition: background-color 0.2s;
 

--- a/frontend/src/pages/Main/MainStyle.ts
+++ b/frontend/src/pages/Main/MainStyle.ts
@@ -210,7 +210,7 @@ export const ContentWrapper = styled.section`
 export const AnnouncementAndSeminar = styled.section`
   flex: 1;
   width: 100%;
-  max-width: 600px;
+  max-width: 800px;
   display: flex;
   flex-direction: column;
   gap: 24px;

--- a/frontend/src/styles/Container.tsx
+++ b/frontend/src/styles/Container.tsx
@@ -19,7 +19,7 @@ const StyledContainer = styled.div<{ $type: ContainerType }>`
       case 'content':
         return 'calc(100% - 0px)'; // 모바일에서는 패딩만 적용
       default:
-        return '85%';
+        return '100%';
     }
   }};
 


### PR DESCRIPTION
- [ ] 💯 테스트는 잘 통과했나요?
- [X] 🏗️ 빌드는 성공했나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?

## 작업 내용
- Header 폰트 크기 및 넓이 조정
- Sector 좌우 여백 제거 및 확장
- 메인페이지의 공지사항 및 세미나 컴포넌트 좌우 크기 변경
- 메인 Banner text-transform 속성 제거, 대문자 표시되도록 변경

## 스크린샷
- 메인페이지 스크린샷, 헤더 폰트 및 하단 Sector 부분 넓이가 커진 것 확인 가능
<img width="1508" alt="스크린샷 2025-02-26 오후 10 29 23" src="https://github.com/user-attachments/assets/98ee6d66-0bef-4a03-9433-508d2faadcb4" />
<img width="1512" alt="스크린샷 2025-02-26 오후 10 29 34" src="https://github.com/user-attachments/assets/95045aac-744e-41a7-b878-fdde711b11bd" />

## 주의사항
- @media 속성을 이용하여, 모바일(768px) 및 태블릿(1024px)에 대한 분기 처리를 하였지만 스타일이 깨지는지에 대한 세부적인 피드백 필요

Closes #{409}