### PR TITLE
[FE] [FEAT] 메인페이지 스타일 재수정

### DIFF
--- a/frontend/src/components/Header/HeaderStyle.ts
+++ b/frontend/src/components/Header/HeaderStyle.ts
@@ -124,7 +124,6 @@ export const HeaderContainer = styled(motion.header)<{
 export const HeaderInner = styled.div`
   max-width: 1400px;
   margin: 0 auto;
-  padding: 0 2rem;
   height: 100%;
   display: flex;
   align-items: center;

--- a/frontend/src/components/Header/Logo/LogoStyle.ts
+++ b/frontend/src/components/Header/Logo/LogoStyle.ts
@@ -55,20 +55,20 @@ export const LogoTitle = styled.div`
   flex-direction: column;
   gap: 4px;
   font-size: 1.6rem;
-  font-weight: 800;
+  font-weight: 700;
   letter-spacing: -0.02em;
   opacity: 0.95;
 `;
 
 export const Department = styled.span`
   font-size: 1.6rem;
-  font-weight: 800;
+  font-weight: 700;
   letter-spacing: -0.02em;
   text-transform: none;
 
   @media (max-width: 768px) {
     font-size: 1.5rem;
-    font-weight: 800;
+    font-weight: 700;
   }
 `;
 
@@ -78,7 +78,7 @@ export const MobileLogoTitle = styled.div`
   transform: translateX(-50%);
   white-space: nowrap;
   font-size: 1.1rem;
-  font-weight: 800;
+  font-weight: 700;
   color: white;
   width: 100%;
   text-align: center;

--- a/frontend/src/components/Header/Navigation/NavItemStyle.ts
+++ b/frontend/src/components/Header/Navigation/NavItemStyle.ts
@@ -14,7 +14,7 @@ export const NavItemLink = styled(Link)<{ isActive?: boolean }>`
   padding: 0 1.6rem; // TopNavItem과 동일한 간격을 위해 조정
   color: white;
   font-size: 1.6rem;
-  font-weight: 600;
+  font-weight: 500;
   white-space: nowrap;
   text-decoration: none;
   background-color: transparent;


### PR DESCRIPTION
- [ ] 💯 테스트는 잘 통과했나요?
- [X] 🏗️ 빌드는 성공했나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?

## 작업 내용
- Header font-weight 100씩 줄임
- HeaderInner padding 삭제, 좌우 여백 줄임 

## 스크린샷
- 변경된 헤더 스크린샷
<img width="1512" alt="스크린샷 2025-02-26 오후 11 48 57" src="https://github.com/user-attachments/assets/482cc126-2ba0-4b8c-b010-1a2e071f6805" />

## 주의사항
- 요구사항 맞게 반영되었는지 확인 필요

Closes #{이슈 번호}