### PR TITLE
ObjectMapper 생성 시 역직렬화 모듈 등록

### DIFF
--- a/backend/src/main/java/org/example/backend/common/aop/logging/LoggingAspect.java
+++ b/backend/src/main/java/org/example/backend/common/aop/logging/LoggingAspect.java
@@ -2,6 +2,7 @@ package org.example.backend.common.aop.logging;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import jakarta.servlet.http.HttpServletRequest;
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -29,7 +30,7 @@ public class LoggingAspect {
 
     private static final List<String> EXCLUDE_NAMES = Arrays.asList("fileList", "request");
     private static final int MAX_RESPONSE_BODY_LENGTH = 65000;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
     private final Logger log = LoggerFactory.getLogger(this.getClass());
 
     private final BulkLogManager bulkLogManager;

--- a/backend/src/main/java/org/example/backend/reservation/repository/ReservationRepository.java
+++ b/backend/src/main/java/org/example/backend/reservation/repository/ReservationRepository.java
@@ -10,8 +10,8 @@ import org.springframework.data.repository.query.Param;
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
     @Query("SELECT COUNT(r) > 0 FROM Reservation r " +
             "WHERE r.room.id = :seminarRoomId " +
-            "AND r.startTime <= :endTime " +
-            "AND r.endTime >= :startTime")
+            "AND r.startTime < :endTime " +
+            "AND r.endTime > :startTime")
     boolean existsByTimePeriod(
             @Param("seminarRoomId") Long seminarRoomId,
             @Param("startTime") LocalDateTime startTime,


### PR DESCRIPTION
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용
![image](https://github.com/user-attachments/assets/ca4a8a95-453d-4660-ae55-e2f2384ca8cf)
### 1.	스프링 MVC의 직렬화 과정
- 일반적으로 @RestController 혹은 @Controller에서 반환된 객체는 스프링이 제공하는 MappingJackson2HttpMessageConverter(내부적으로 ObjectMapper 사용)를 통해 JSON으로 변환됩니다.
- 스프링 부트를 쓰고 있고 com.fasterxml.jackson.datatype:jackson-datatype-jsr310 라이브러리를 의존성에 추가했다면, 스프링 부트의 자동설정(autoconfiguration)이 ObjectMapper에 JavaTimeModule 등을 자동으로 등록해 줍니다.
- 따라서 LocalDateTime 같은 Java 8 날짜/시간 타입이 별도의 설정 없이도 정상적으로 직렬화/역직렬화가 가능한 겁니다.

### 2.	AOP 로깅에서의 직렬화
- 반면, 질문 코드에서 보면 AOP 클래스(LoggingAspect) 내부에 new ObjectMapper()를 통해 새로운 ObjectMapper 인스턴스를 생성하고 있습니다.
- 이렇게 따로 만든 ObjectMapper는 스프링이 자동 등록해준 모듈(예: JavaTimeModule)이 빠진 상태이므로, LocalDateTime을 직렬화하려고 하면 에러가 납니다.
- 그래서 “GET으로 조회할 때는 전혀 문제 없다가, 로깅할 때만 LocalDateTime 직렬화 오류”가 발생했습니다.

따라서 MappingJackson2HttpMessageConverter 처럼 JavaTimeModule을 따로 등록해주어 역직렬화를 해줬습니다.
```java
private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
```

## 스크린샷
<img width="650" alt="image" src="https://github.com/user-attachments/assets/c592a484-a54b-4725-9ef6-d0657828260a" />


## 주의사항
핸들러 어댑터와 핸들러 사이의 변환과정을 이해하자.

Closes #416