### PR TITLE
[FE] [FEAT] 헤더 폰트 크기 및 여백 수정 

### DIFF
--- a/frontend/src/components/Header/HeaderStyle.ts
+++ b/frontend/src/components/Header/HeaderStyle.ts
@@ -25,8 +25,9 @@ export const TopHeaderInner = styled.div`
   }
 `;
 
-export const TopHeaderTitle = styled.div`
+export const TopHeaderTitle = styled.a`
   color: white;
+  text-decoration: none;
   font-size: 1.1rem;
   font-weight: 700;
   letter-spacing: 0.02em;

--- a/frontend/src/components/Header/HeaderStyle.ts
+++ b/frontend/src/components/Header/HeaderStyle.ts
@@ -15,7 +15,6 @@ export const TopHeaderContainer = styled.div`
 export const TopHeaderInner = styled.div`
   max-width: 1400px;
   margin: 0 auto;
-  padding: 0 2rem;
   height: 100%;
   display: flex;
   align-items: center;

--- a/frontend/src/components/Header/Logo/LogoStyle.ts
+++ b/frontend/src/components/Header/Logo/LogoStyle.ts
@@ -54,20 +54,20 @@ export const LogoTitle = styled.div`
   display: flex;
   flex-direction: column;
   gap: 4px;
-  font-size: 1.6rem;
+  font-size: 1.4rem;
   font-weight: 700;
   letter-spacing: -0.02em;
   opacity: 0.95;
 `;
 
 export const Department = styled.span`
-  font-size: 1.6rem;
+  font-size: 1.4rem;
   font-weight: 700;
   letter-spacing: -0.02em;
   text-transform: none;
 
   @media (max-width: 768px) {
-    font-size: 1.5rem;
+    font-size: 1.3rem;
     font-weight: 700;
   }
 `;

--- a/frontend/src/components/Header/Logo/LogoStyle.ts
+++ b/frontend/src/components/Header/Logo/LogoStyle.ts
@@ -20,7 +20,6 @@ export const LogoLink = styled(Link)`
   text-decoration: none;
   color: white;
   transition: opacity 0.2s ease;
-
   &:hover {
     opacity: 0.9;
   }

--- a/frontend/src/components/Header/Navigation/NavItemStyle.ts
+++ b/frontend/src/components/Header/Navigation/NavItemStyle.ts
@@ -11,7 +11,7 @@ export const NavItemLink = styled(Link)<{ isActive?: boolean }>`
   display: inline-flex;
   align-items: center;
   height: 100%;
-  padding: 0 1.4rem; // TopNavItem과 동일한 간격을 위해 조정
+  padding: 0 1.6rem; // TopNavItem과 동일한 간격을 위해 조정
   color: white;
   font-size: 1.4rem;
   font-weight: 500;

--- a/frontend/src/components/Header/Navigation/NavItemStyle.ts
+++ b/frontend/src/components/Header/Navigation/NavItemStyle.ts
@@ -11,9 +11,9 @@ export const NavItemLink = styled(Link)<{ isActive?: boolean }>`
   display: inline-flex;
   align-items: center;
   height: 100%;
-  padding: 0 1.6rem; // TopNavItem과 동일한 간격을 위해 조정
+  padding: 0 1.4rem; // TopNavItem과 동일한 간격을 위해 조정
   color: white;
-  font-size: 1.6rem;
+  font-size: 1.4rem;
   font-weight: 500;
   white-space: nowrap;
   text-decoration: none;

--- a/frontend/src/components/Header/TopHeader.tsx
+++ b/frontend/src/components/Header/TopHeader.tsx
@@ -57,10 +57,16 @@ const TopHeader: React.FC = () => {
   return (
     <TopHeaderContainer>
       <TopHeaderInner>
-        <TopHeaderTitle>SEJONG UNIVERSITY</TopHeaderTitle>
+        <TopHeaderTitle
+          href="http://sejong.ac.kr/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          SEJONG UNIVERSITY
+        </TopHeaderTitle>
         <TopNavList>
           <TopNavItem>
-            <a href="http://sejong.ac.kr/">HOME</a>
+            <a href="/">HOME</a>
           </TopNavItem>
           <TopNavItem>
             <a href="/about/organization">CONTACT</a>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -26,9 +26,9 @@ body {
 
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
+    'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }


### PR DESCRIPTION
- [ ] 💯 테스트는 잘 통과했나요?
- [X] 🏗️ 빌드는 성공했나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?

## 작업 내용
- TopHeader Padding 제거
- Header 폰트 크기 0.2 줄여 크기 조정
- HeaderInner 좌우 여백 조정 
- TopHeader 링크 조정
- prettier 규칙에 맞게 npx prettier --write . 로 파일들 재정렬

## 스크린샷
- 노트북 해상도 기준 Header 스크린샷
<img width="1512" alt="스크린샷 2025-02-28 오후 4 55 38" src="https://github.com/user-attachments/assets/9a82a553-5bf7-442d-921b-9894ce80c070" />


## 주의사항

Closes #409