### PR TITLE
[BE] getwriter() has already been called for this response 해결 & 뉴스 조회수 로직 추가

### DIFF
--- a/backend/src/main/java/org/example/backend/board/service/BoardService.java
+++ b/backend/src/main/java/org/example/backend/board/service/BoardService.java
@@ -96,34 +96,17 @@ public class BoardService {
     }
 
     @Transactional
-    public void incrementViewCount(Long boardId, HttpServletRequest request, HttpServletResponse response) {
-        Cookie oldCookie = null;
-        Cookie[] cookies = request.getCookies();
-
-        if (cookies != null) {
-            for (Cookie cookie : cookies) {
-                if (cookie.getName().equals("postView")) {
-                    oldCookie = cookie;
-                    break;
-                }
-            }
-        }
-
-        if (oldCookie != null) {
-            if (!oldCookie.getValue().contains("[" + boardId + "]")) {
-                readCount(boardId);
-                oldCookie.setValue(oldCookie.getValue() + "_[" + boardId + "]");
-                oldCookie.setPath("/");
-                oldCookie.setMaxAge(60 * 60 * 24);
-                response.addCookie(oldCookie);
-            }
-        } else {
+    public String incrementViewCount(Long boardId, String postViewCookie) {
+        if (postViewCookie == null || !postViewCookie.contains("[" + boardId + "]")) {
             readCount(boardId);
-            Cookie newCookie = new Cookie("postView", "[" + boardId + "]");
-            newCookie.setPath("/");
-            newCookie.setMaxAge(60 * 60 * 24);
-            response.addCookie(newCookie);
+
+            if (postViewCookie == null || postViewCookie.isEmpty()) {
+                return "[" + boardId + "]";
+            }
+            return postViewCookie + "_[" + boardId + "]";
         }
+
+        return postViewCookie;
     }
 
     @Transactional

--- a/backend/src/main/java/org/example/backend/news/repository/NewsRepository.java
+++ b/backend/src/main/java/org/example/backend/news/repository/NewsRepository.java
@@ -4,6 +4,7 @@ import org.example.backend.news.domain.entity.News;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -25,4 +26,8 @@ public interface NewsRepository extends JpaRepository<News, Long> {
     """,
     nativeQuery = true)
     Page<News> searchByKeyword(@Param("keyword") String keyword, Pageable pageable);
+
+    @Modifying
+    @Query("UPDATE News n SET n.view = n.view + 1 WHERE n.id = :newsId")
+    void incrementViewCount(@Param("newsId") Long newsId);
 }

--- a/backend/src/main/java/org/example/backend/news/service/NewsService.java
+++ b/backend/src/main/java/org/example/backend/news/service/NewsService.java
@@ -73,6 +73,24 @@ public class NewsService {
         return newsRepository.findAll(pageable)
                 .map(NewsResDto::of);
     }
+    @Transactional
+    public String incrementViewCount(Long newsId, String newsViewCookie) {
+        if (newsViewCookie == null || !newsViewCookie.contains("[" + newsId + "]")) {
+            readCount(newsId);
+
+            if (newsViewCookie == null || newsViewCookie.isEmpty()) {
+                return "[" + newsId + "]";
+            }
+            return newsViewCookie + "_[" + newsId + "]";
+        }
+
+        return newsViewCookie;
+    }
+
+    @Transactional
+    public void readCount(Long newsId) {
+        newsRepository.incrementViewCount(newsId);
+    }
 
     public Page<NewsResDto> searchNews(String keyword, Pageable pageable) {
         return newsRepository.searchByKeyword(keyword, pageable)


### PR DESCRIPTION
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용

기존에는 다음과 같은 방식으로 조회수 증가 로직을 구현했었는데요...

Controller 레벨에서 HttpServletRequest, HttpServletResponse를 파라미터로 받아옴
Service 계층에 이들을 그대로 전달 (boardService.incrementViewCount(boardId, request, response))
Service 내부에서:
request.getCookies()로 쿠키를 읽고
쿠키가 없거나, [boardId]가 포함되어 있지 않으면 DB에서 해당 boardId의 조회수를 증가
response.addCookie(...)로 쿠키를 갱신

근데 이렇게 하면 응답 스트림(getWriter() vs getOutputStream()) 충돌이 발생햇습니다..
또 AOP나 필터, 예외 처리 등에서 응답을 한 번 write하거나 flush하면,
이후에 또 다른 로직에서 응답을 생성하려고 할 때 IllegalStateException: getWriter() has already been called for this response 에러가 발생하는 문제를 해결하고자  @CookieValue로 해결했습니다

또한, HttpServletRequest / HttpServletResponse를 Service 계층까지 끌고 가면
테스트가 어려워지고 스프링 Servlet API에 과도하게 의존하게 되서 왠만하면 안쓰는걸 추천드릴게요ㅎㅎ;

## 주의사항

Closes #423 