### PR TITLE
[FE] [FEAT] 메인페이지 변경된 컴포넌트 구현

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,6 +41,7 @@
     "react-calendar": "^5.1.0",
     "react-dom": "^18.3.1",
     "react-error-boundary": "^5.0.0",
+    "react-icons": "^5.5.0",
     "react-markdown": "^9.0.1",
     "react-quill": "^2.0.0",
     "react-quill-new": "^3.3.3",

--- a/frontend/src/components/NewsSlider/NewsSlider.tsx
+++ b/frontend/src/components/NewsSlider/NewsSlider.tsx
@@ -39,11 +39,12 @@ const NewsSlider: React.FC<NewsSliderProps> = ({
   onNewsClick,
 }) => {
   const getItemsPerView = () => {
-    if (typeof window === 'undefined') return 4;
+    if (typeof window === 'undefined') return 5;
     if (window.innerWidth <= 480) return 1;
     if (window.innerWidth <= 768) return 2;
     if (window.innerWidth <= 1024) return 3;
-    return 4;
+    if (window.innerWidth <= 1366) return 4;
+    return 5;
   };
 
   const [currentIndex, setCurrentIndex] = useState(0);

--- a/frontend/src/components/NewsSlider/NewsSliderStyle.ts
+++ b/frontend/src/components/NewsSlider/NewsSliderStyle.ts
@@ -27,7 +27,6 @@ export const SliderContainer = styled.div`
   width: 100%;
   margin: 0 auto;
   position: relative;
-  padding: 0 40px;
   z-index: 1;
 
   ${media.mobile} {

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -31,9 +31,7 @@ const MainContent = styled(motion.main)<{ $isAuthPage: boolean }>`
   height: 100%;
   align-items: center;
   padding: ${(props) =>
-    props.$isAuthPage
-      ? '0'
-      : '20px 0 40px'}; // Default padding for non-auth pages
+    props.$isAuthPage ? '0' : '0 0 40px'}; // Default padding for non-auth pages
 
   ${media.mobile} {
     padding: ${(props) =>

--- a/frontend/src/pages/Main/Main.tsx
+++ b/frontend/src/pages/Main/Main.tsx
@@ -6,11 +6,13 @@ import { ShortcutSection } from './components/ShortcutSection';
 import { PaperSection } from './components/PaperSection';
 import { NewsSection } from './components/NewsSection';
 import Container from '../../styles/Container';
+import ButtonListSection from './components/ButtonListSection/ButtonListSection';
 
 function Main(): JSX.Element {
   return (
     <>
       <Container>
+        <ButtonListSection />
         <ContentWrapper>
           <AnnouncementAndSeminar>
             <AnnouncementSection />

--- a/frontend/src/pages/Main/Main.tsx
+++ b/frontend/src/pages/Main/Main.tsx
@@ -11,8 +11,8 @@ import ButtonListSection from './components/ButtonListSection/ButtonListSection'
 function Main(): JSX.Element {
   return (
     <>
+      <ButtonListSection />
       <Container>
-        <ButtonListSection />
         <ContentWrapper>
           <AnnouncementAndSeminar>
             <AnnouncementSection />

--- a/frontend/src/pages/Main/Main.tsx
+++ b/frontend/src/pages/Main/Main.tsx
@@ -18,7 +18,7 @@ function Main(): JSX.Element {
           </AnnouncementAndSeminar>
           <ShortcutSection />
         </ContentWrapper>
-        <PaperSection />
+        {/* <PaperSection /> */}
         <NewsSection />
       </Container>
     </>

--- a/frontend/src/pages/Main/Main.tsx
+++ b/frontend/src/pages/Main/Main.tsx
@@ -14,7 +14,7 @@ function Main(): JSX.Element {
         <ContentWrapper>
           <AnnouncementAndSeminar>
             <AnnouncementSection />
-            <SeminarSection />
+            {/* <SeminarSection /> */}
           </AnnouncementAndSeminar>
           <ShortcutSection />
         </ContentWrapper>

--- a/frontend/src/pages/Main/Main.tsx
+++ b/frontend/src/pages/Main/Main.tsx
@@ -7,6 +7,7 @@ import { PaperSection } from './components/PaperSection';
 import { NewsSection } from './components/NewsSection';
 import Container from '../../styles/Container';
 import ButtonListSection from './components/ButtonListSection/ButtonListSection';
+import VerticalButtonSection from './components/VerticalButtonSection/VerticalButtonSection';
 
 function Main(): JSX.Element {
   return (
@@ -18,7 +19,8 @@ function Main(): JSX.Element {
             <AnnouncementSection />
             {/* <SeminarSection /> */}
           </AnnouncementAndSeminar>
-          <ShortcutSection />
+          {/* <ShortcutSection /> */}
+          <VerticalButtonSection />
         </ContentWrapper>
         {/* <PaperSection /> */}
         <NewsSection />

--- a/frontend/src/pages/Main/MainStyle.ts
+++ b/frontend/src/pages/Main/MainStyle.ts
@@ -191,7 +191,7 @@ export const ContentWrapper = styled.section`
   margin: 48px auto;
   padding: 0 20px;
   max-width: 1200px;
-  gap: 24px;
+  gap: 30px;
 
   ${media.tablet} {
     margin: 32px auto;

--- a/frontend/src/pages/Main/components/ButtonListSection/ButtonListSection.tsx
+++ b/frontend/src/pages/Main/components/ButtonListSection/ButtonListSection.tsx
@@ -9,7 +9,7 @@ import {
   InfoIconWrapper,
 } from './ButtonListSectionStyle';
 
-import { buttonItems } from './data'; 
+import { buttonItems } from './data';
 
 const ButtonListSection: React.FC = () => {
   return (

--- a/frontend/src/pages/Main/components/ButtonListSection/ButtonListSection.tsx
+++ b/frontend/src/pages/Main/components/ButtonListSection/ButtonListSection.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import {
+  ButtonListContainer,
+  ButtonListList,
+  ButtonListItem,
+} from './ButtonListSectionStyle';
+
+// 아이콘과 링크, 텍스트 등을 실제 데이터로 교체하면 됩니다.
+const buttonItems = [
+  {
+    title: '세종대학교',
+    icon: '/icons/univ.svg', // 예: 아이콘 경로
+    link: 'https://www.sejong.ac.kr/', // 예: 외부 링크
+  },
+  {
+    title: '장학안내',
+    icon: '/icons/scholarship.svg',
+    link: '#',
+  },
+  {
+    title: '포털 시스템',
+    icon: '/icons/portal.svg',
+    link: '#',
+  },
+  {
+    title: '학생회 안내',
+    icon: '/icons/student.svg',
+    link: '#',
+  },
+  {
+    title: '세미나 정보',
+    icon: '/icons/seminar.svg',
+    link: '#',
+  },
+];
+
+const ButtonListSection: React.FC = () => {
+  return (
+    <ButtonListContainer>
+      <ButtonListList>
+        {buttonItems.map((item, index) => (
+          <ButtonListItem key={index}>
+            <a href={item.link} target="_blank" rel="noopener noreferrer">
+              {/* 아이콘이 없다면 img 태그는 빼거나 아이콘 폰트 등을 사용해도 됩니다. */}
+              <img src={item.icon} alt={item.title} />
+              <span>{item.title}</span>
+            </a>
+          </ButtonListItem>
+        ))}
+      </ButtonListList>
+    </ButtonListContainer>
+  );
+};
+
+export default ButtonListSection;

--- a/frontend/src/pages/Main/components/ButtonListSection/ButtonListSection.tsx
+++ b/frontend/src/pages/Main/components/ButtonListSection/ButtonListSection.tsx
@@ -3,34 +3,57 @@ import {
   ButtonListContainer,
   ButtonListList,
   ButtonListItem,
+  SeminarInfoWrapper,
+  SeminarInfoTitle,
+  SeminarInfoSubtitle,
+  InfoIconWrapper,
 } from './ButtonListSectionStyle';
 
-// 아이콘과 링크, 텍스트 등을 실제 데이터로 교체하면 됩니다.
-const buttonItems = [
+// react-icons에서 사용할 아이콘 불러오기
+import {
+  FaUniversity,
+  FaGraduationCap,
+  FaGlobe,
+  FaUsers,
+  FaChalkboardTeacher,
+} from 'react-icons/fa';
+import { IconBaseProps } from 'react-icons';
+
+const buttonItems: {
+  title: string;
+  icon: React.ComponentType<IconBaseProps>; // 아이콘 타입
+  link: string;
+  isSeminar: boolean;
+}[] = [
   {
     title: '세종대학교',
-    icon: '/icons/univ.svg', // 예: 아이콘 경로
-    link: 'https://www.sejong.ac.kr/', // 예: 외부 링크
+    icon: FaUniversity as React.ComponentType<IconBaseProps>,
+    link: '/',
+    isSeminar: false,
   },
   {
     title: '장학안내',
-    icon: '/icons/scholarship.svg',
-    link: '#',
+    icon: FaGraduationCap as React.ComponentType<IconBaseProps>,
+    link: '/',
+    isSeminar: false,
   },
   {
     title: '포털 시스템',
-    icon: '/icons/portal.svg',
-    link: '#',
+    icon: FaGlobe as React.ComponentType<IconBaseProps>,
+    link: '/',
+    isSeminar: false,
   },
   {
     title: '학생회 안내',
-    icon: '/icons/student.svg',
-    link: '#',
+    icon: FaUsers as React.ComponentType<IconBaseProps>,
+    link: '/',
+    isSeminar: false,
   },
   {
     title: '세미나 정보',
-    icon: '/icons/seminar.svg',
-    link: '#',
+    icon: FaChalkboardTeacher as React.ComponentType<IconBaseProps>,
+    link: '/',
+    isSeminar: true,
   },
 ];
 
@@ -38,15 +61,39 @@ const ButtonListSection: React.FC = () => {
   return (
     <ButtonListContainer>
       <ButtonListList>
-        {buttonItems.map((item, index) => (
-          <ButtonListItem key={index}>
-            <a href={item.link} target="_blank" rel="noopener noreferrer">
-              {/* 아이콘이 없다면 img 태그는 빼거나 아이콘 폰트 등을 사용해도 됩니다. */}
-              <img src={item.icon} alt={item.title} />
-              <span>{item.title}</span>
-            </a>
-          </ButtonListItem>
-        ))}
+        {buttonItems.map((item, index) => {
+          if (item.isSeminar) {
+            // 마지막 '세미나 정보' 아이템
+            return (
+              <ButtonListItem key={index} isSeminar>
+                <SeminarInfoWrapper>
+                  <SeminarInfoTitle>세미나</SeminarInfoTitle>
+                  <SeminarInfoSubtitle>최신 세미나 제목</SeminarInfoSubtitle>
+                  <SeminarInfoSubtitle>최신 세미나 일정</SeminarInfoSubtitle>
+                  <SeminarInfoSubtitle>최신 세미나 담당자</SeminarInfoSubtitle>
+                  <SeminarInfoSubtitle>
+                    최신 세미나 진행 장소
+                  </SeminarInfoSubtitle>
+                  <InfoIconWrapper>
+                    <span>i</span>
+                  </InfoIconWrapper>
+                </SeminarInfoWrapper>
+              </ButtonListItem>
+            );
+          }
+
+          // 일반 버튼 아이템
+          return (
+            <ButtonListItem key={index} isSeminar={item.isSeminar}>
+              <a href={item.link} target="_blank" rel="noopener noreferrer">
+                {React.createElement(item.icon, {
+                  size: 0 /* 무시하거나 기본값 */,
+                })}
+                <span>{item.title}</span>
+              </a>
+            </ButtonListItem>
+          );
+        })}
       </ButtonListList>
     </ButtonListContainer>
   );

--- a/frontend/src/pages/Main/components/ButtonListSection/ButtonListSection.tsx
+++ b/frontend/src/pages/Main/components/ButtonListSection/ButtonListSection.tsx
@@ -9,53 +9,7 @@ import {
   InfoIconWrapper,
 } from './ButtonListSectionStyle';
 
-// react-icons에서 사용할 아이콘 불러오기
-import {
-  FaUniversity,
-  FaGraduationCap,
-  FaGlobe,
-  FaUsers,
-  FaChalkboardTeacher,
-} from 'react-icons/fa';
-import { IconBaseProps } from 'react-icons';
-
-const buttonItems: {
-  title: string;
-  icon: React.ComponentType<IconBaseProps>; // 아이콘 타입
-  link: string;
-  isSeminar: boolean;
-}[] = [
-  {
-    title: '세종대학교',
-    icon: FaUniversity as React.ComponentType<IconBaseProps>,
-    link: '/',
-    isSeminar: false,
-  },
-  {
-    title: '장학안내',
-    icon: FaGraduationCap as React.ComponentType<IconBaseProps>,
-    link: '/',
-    isSeminar: false,
-  },
-  {
-    title: '포털 시스템',
-    icon: FaGlobe as React.ComponentType<IconBaseProps>,
-    link: '/',
-    isSeminar: false,
-  },
-  {
-    title: '학생회 안내',
-    icon: FaUsers as React.ComponentType<IconBaseProps>,
-    link: '/',
-    isSeminar: false,
-  },
-  {
-    title: '세미나 정보',
-    icon: FaChalkboardTeacher as React.ComponentType<IconBaseProps>,
-    link: '/',
-    isSeminar: true,
-  },
-];
+import { buttonItems } from './data'; // 데이터 임포트
 
 const ButtonListSection: React.FC = () => {
   return (

--- a/frontend/src/pages/Main/components/ButtonListSection/ButtonListSection.tsx
+++ b/frontend/src/pages/Main/components/ButtonListSection/ButtonListSection.tsx
@@ -9,7 +9,7 @@ import {
   InfoIconWrapper,
 } from './ButtonListSectionStyle';
 
-import { buttonItems } from './data'; // 데이터 임포트
+import { buttonItems } from './data'; 
 
 const ButtonListSection: React.FC = () => {
   return (
@@ -39,9 +39,9 @@ const ButtonListSection: React.FC = () => {
           // 일반 버튼 아이템
           return (
             <ButtonListItem key={index} isSeminar={item.isSeminar}>
-              <a href={item.link} target="_blank" rel="noopener noreferrer">
+              <a href={item.link} rel="noopener noreferrer">
                 {React.createElement(item.icon, {
-                  size: 0 /* 무시하거나 기본값 */,
+                  size: 0,
                 })}
                 <span>{item.title}</span>
               </a>

--- a/frontend/src/pages/Main/components/ButtonListSection/ButtonListSectionStyle.ts
+++ b/frontend/src/pages/Main/components/ButtonListSection/ButtonListSectionStyle.ts
@@ -1,66 +1,143 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 export const ButtonListContainer = styled.section`
   width: 100%;
-  margin: 2rem 0;
+  margin: 0 auto;
 `;
 
 export const ButtonListList = styled.ul`
   display: flex;
   justify-content: space-between;
-  align-items: stretch; /* 아이템 높이를 맞추고 싶으면 stretch */
+  align-items: stretch;
   list-style: none;
-  padding: 0;
   margin: 0;
+  padding: 0;
 
-  /* 화면이 좁아졌을 때 아이템들이 줄바꿈되어 2열 이상으로 배치되도록 */
   @media (max-width: 768px) {
     flex-wrap: wrap;
   }
 `;
 
-export const ButtonListItem = styled.li`
+interface ButtonListItemProps {
+  isSeminar?: boolean;
+}
+
+export const ButtonListItem = styled.li<ButtonListItemProps>`
   flex: 1;
-  margin: 0 0.5rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: #fff;
+  border-left: 1px solid #ddd;
 
   &:first-child {
-    margin-left: 0;
-  }
-  &:last-child {
-    margin-right: 0;
+    border-left: none;
   }
 
+  ${({ isSeminar }) =>
+    isSeminar &&
+    css`
+      background-color: #a30027;
+      color: #fff;
+      position: relative;
+      flex: 1.5;
+      display: block;
+    `}
+
   a {
+    width: 100%;
+    height: 100%;
+    padding: 2rem 1rem;
     display: flex;
-    flex-direction: column; /* 아이콘과 텍스트를 세로 배치 */
+    flex-direction: column;
     align-items: center;
     justify-content: center;
     text-decoration: none;
-    color: inherit; /* 부모 컬러 상속 */
-    border: 1px solid #eee;
-    border-radius: 8px;
-    padding: 1rem;
+    color: inherit;
     transition: background-color 0.3s ease;
 
     img {
-      width: 40px;
-      height: 40px;
+      width: 64px;
+      height: 64px;
       margin-bottom: 0.5rem;
     }
 
     span {
-      font-size: 1rem;
-      font-weight: 500;
+      font-size: 1.5rem;
+      font-weight: 800;
+      padding: 1rem 0;
+    }
+
+    svg {
+      width: 6rem;
+      height: 6rem;
     }
 
     &:hover {
       background-color: #f9f9f9;
+
+      span {
+        color: #a30027;
+      }
+
+      svg {
+        color: #a30027;
+      }
+    }
+
+    @media (max-width: 768px) {
+      svg {
+        width: 3rem;
+        height: 3rem;
+      }
     }
   }
 
-  /* 모바일 환경에서는 2개씩 배치 */
   @media (max-width: 768px) {
-    flex: 0 0 calc(50% - 1rem);
-    margin-bottom: 1rem;
+    flex: 0 0 calc(50% - 1px);
+
+    ${({ isSeminar }) =>
+      isSeminar &&
+      css`
+        flex: 0 0 100%;
+        margin-top: 1rem;
+      `}
+  }
+`;
+
+export const SeminarInfoWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 2rem;
+  height: 100%;
+`;
+
+export const SeminarInfoTitle = styled.h3`
+  font-size: 1.5rem;
+  margin: 0 0 1rem 0;
+`;
+
+export const SeminarInfoSubtitle = styled.p`
+  font-size: 1rem;
+  margin: 0.25rem 0;
+  line-height: 1.4;
+`;
+
+export const InfoIconWrapper = styled.div`
+  position: absolute;
+  bottom: 1rem;
+  right: 1rem;
+  width: 32px;
+  height: 32px;
+  border: 2px solid #fff;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  span {
+    color: #fff;
+    font-weight: bold;
   }
 `;

--- a/frontend/src/pages/Main/components/ButtonListSection/ButtonListSectionStyle.ts
+++ b/frontend/src/pages/Main/components/ButtonListSection/ButtonListSectionStyle.ts
@@ -1,0 +1,66 @@
+import styled from 'styled-components';
+
+export const ButtonListContainer = styled.section`
+  width: 100%;
+  margin: 2rem 0;
+`;
+
+export const ButtonListList = styled.ul`
+  display: flex;
+  justify-content: space-between;
+  align-items: stretch; /* 아이템 높이를 맞추고 싶으면 stretch */
+  list-style: none;
+  padding: 0;
+  margin: 0;
+
+  /* 화면이 좁아졌을 때 아이템들이 줄바꿈되어 2열 이상으로 배치되도록 */
+  @media (max-width: 768px) {
+    flex-wrap: wrap;
+  }
+`;
+
+export const ButtonListItem = styled.li`
+  flex: 1;
+  margin: 0 0.5rem;
+
+  &:first-child {
+    margin-left: 0;
+  }
+  &:last-child {
+    margin-right: 0;
+  }
+
+  a {
+    display: flex;
+    flex-direction: column; /* 아이콘과 텍스트를 세로 배치 */
+    align-items: center;
+    justify-content: center;
+    text-decoration: none;
+    color: inherit; /* 부모 컬러 상속 */
+    border: 1px solid #eee;
+    border-radius: 8px;
+    padding: 1rem;
+    transition: background-color 0.3s ease;
+
+    img {
+      width: 40px;
+      height: 40px;
+      margin-bottom: 0.5rem;
+    }
+
+    span {
+      font-size: 1rem;
+      font-weight: 500;
+    }
+
+    &:hover {
+      background-color: #f9f9f9;
+    }
+  }
+
+  /* 모바일 환경에서는 2개씩 배치 */
+  @media (max-width: 768px) {
+    flex: 0 0 calc(50% - 1rem);
+    margin-bottom: 1rem;
+  }
+`;

--- a/frontend/src/pages/Main/components/ButtonListSection/data.ts
+++ b/frontend/src/pages/Main/components/ButtonListSection/data.ts
@@ -1,0 +1,57 @@
+import { IconBaseProps } from 'react-icons';
+import {
+  FaUniversity,
+  FaGraduationCap,
+  FaGlobe,
+  FaUsers,
+  FaChalkboardTeacher,
+} from 'react-icons/fa';
+
+// 아이콘을 "React.ComponentType<IconBaseProps>" 형태로 캐스팅
+const UniversityIcon = FaUniversity as React.ComponentType<IconBaseProps>;
+const ScholarshipIcon = FaGraduationCap as React.ComponentType<IconBaseProps>;
+const PortalIcon = FaGlobe as React.ComponentType<IconBaseProps>;
+const StudentIcon = FaUsers as React.ComponentType<IconBaseProps>;
+const SeminarIcon = FaChalkboardTeacher as React.ComponentType<IconBaseProps>;
+
+/** ButtonList에서 사용할 데이터 구조 */
+export interface ButtonItem {
+  title: string;
+  icon: React.ComponentType<IconBaseProps>;
+  link: string;
+  isSeminar: boolean;
+}
+
+/** 실제 렌더링할 데이터 목록 */
+export const buttonItems: ButtonItem[] = [
+  {
+    title: '세종대학교',
+    icon: UniversityIcon,
+    link: '/',
+    isSeminar: false,
+  },
+  {
+    title: '장학안내',
+    icon: ScholarshipIcon,
+    link: '/',
+    isSeminar: false,
+  },
+  {
+    title: '포털 시스템',
+    icon: PortalIcon,
+    link: '/',
+    isSeminar: false,
+  },
+  {
+    title: '학생회 안내',
+    icon: StudentIcon,
+    link: '/',
+    isSeminar: false,
+  },
+  {
+    title: '세미나 정보',
+    icon: SeminarIcon,
+    link: '/',
+    isSeminar: true,
+  },
+];

--- a/frontend/src/pages/Main/components/ButtonListSection/data.ts
+++ b/frontend/src/pages/Main/components/ButtonListSection/data.ts
@@ -7,14 +7,11 @@ import {
   FaChalkboardTeacher,
 } from 'react-icons/fa';
 
-// 아이콘을 "React.ComponentType<IconBaseProps>" 형태로 캐스팅
 const UniversityIcon = FaUniversity as React.ComponentType<IconBaseProps>;
 const ScholarshipIcon = FaGraduationCap as React.ComponentType<IconBaseProps>;
 const PortalIcon = FaGlobe as React.ComponentType<IconBaseProps>;
 const StudentIcon = FaUsers as React.ComponentType<IconBaseProps>;
 const SeminarIcon = FaChalkboardTeacher as React.ComponentType<IconBaseProps>;
-
-/** ButtonList에서 사용할 데이터 구조 */
 export interface ButtonItem {
   title: string;
   icon: React.ComponentType<IconBaseProps>;
@@ -22,7 +19,6 @@ export interface ButtonItem {
   isSeminar: boolean;
 }
 
-/** 실제 렌더링할 데이터 목록 */
 export const buttonItems: ButtonItem[] = [
   {
     title: '세종대학교',

--- a/frontend/src/pages/Main/components/VerticalButtonSection/VerticalButtonSection.tsx
+++ b/frontend/src/pages/Main/components/VerticalButtonSection/VerticalButtonSection.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import styled from 'styled-components';
+import { IconBaseProps } from 'react-icons';
+import { FaChalkboardTeacher } from 'react-icons/fa';
+import { FaBook } from 'react-icons/fa';
+import { AiOutlineArrowRight } from 'react-icons/ai';
+
+const ProfessorIcon = FaChalkboardTeacher as React.ComponentType<IconBaseProps>;
+const BookIcon = FaBook as React.ComponentType<IconBaseProps>;
+const ArrowIcon = AiOutlineArrowRight as React.ComponentType<IconBaseProps>;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  flex: 0.6;
+`;
+
+const CardButton = styled.a`
+  display: flex;
+  align-items: center;
+  background-color: #e9dfda;
+  border-radius: 8px;
+  padding: 1.5rem;
+  flex: 1;
+  text-decoration: none;
+  color: #333;
+  transition: background-color 0.2s ease;
+
+  &:hover {
+    background-color: #d8cdc6;
+  }
+
+  @media (max-width: 768px) {
+    padding: 1rem;
+  }
+`;
+
+const IconWrapper = styled.div`
+  margin-right: 1rem;
+  font-size: 3rem;
+  color: #a30027;
+
+  @media (max-width: 768px) {
+    font-size: 2rem;
+  }
+`;
+
+const TextWrapper = styled.div`
+  flex: 1;
+`;
+
+const Title = styled.h3`
+  font-size: 1.2rem;
+  margin: 0;
+  font-weight: bold;
+
+  @media (max-width: 768px) {
+    font-size: 1.05rem;
+  }
+`;
+
+const SubText = styled.p`
+  margin: 0.25rem 0 0;
+  font-size: 0.95rem;
+  color: #555;
+
+  @media (max-width: 768px) {
+    font-size: 0.85rem;
+  }
+`;
+
+const ArrowWrapper = styled.div`
+  margin-left: auto;
+  font-size: 1.5rem;
+  color: #a30027;
+
+  @media (max-width: 768px) {
+    font-size: 1.2rem;
+  }
+`;
+
+const VerticalButtonSection: React.FC = () => {
+  return (
+    <Container>
+      <CardButton href="/">
+        <IconWrapper>
+          <ProfessorIcon />
+        </IconWrapper>
+        <TextWrapper>
+          <Title>교수진 소개</Title>
+          <SubText>Meet our esteemed professors</SubText>
+        </TextWrapper>
+        <ArrowWrapper>
+          <ArrowIcon />
+        </ArrowWrapper>
+      </CardButton>
+
+      <CardButton href="/">
+        <IconWrapper>
+          <BookIcon />
+        </IconWrapper>
+        <TextWrapper>
+          <Title>교과과정 안내</Title>
+          <SubText>See our curriculum details</SubText>
+        </TextWrapper>
+        <ArrowWrapper>
+          <ArrowIcon />
+        </ArrowWrapper>
+      </CardButton>
+    </Container>
+  );
+};
+
+export default VerticalButtonSection;

--- a/frontend/src/pages/Main/components/VerticalButtonSection/VerticalButtonSection.tsx
+++ b/frontend/src/pages/Main/components/VerticalButtonSection/VerticalButtonSection.tsx
@@ -1,113 +1,38 @@
 import React from 'react';
-import styled from 'styled-components';
 import { IconBaseProps } from 'react-icons';
-import { FaChalkboardTeacher } from 'react-icons/fa';
-import { FaBook } from 'react-icons/fa';
 import { AiOutlineArrowRight } from 'react-icons/ai';
 
-const ProfessorIcon = FaChalkboardTeacher as React.ComponentType<IconBaseProps>;
-const BookIcon = FaBook as React.ComponentType<IconBaseProps>;
+import {
+  Container,
+  CardButton,
+  IconWrapper,
+  TextWrapper,
+  Title,
+  SubText,
+  ArrowWrapper,
+} from './VerticalButtonSectionStyle';
+
+import { cardData } from './data';
+
 const ArrowIcon = AiOutlineArrowRight as React.ComponentType<IconBaseProps>;
-
-const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  flex: 0.6;
-`;
-
-const CardButton = styled.a`
-  display: flex;
-  align-items: center;
-  background-color: #e9dfda;
-  border-radius: 8px;
-  padding: 1.5rem;
-  flex: 1;
-  text-decoration: none;
-  color: #333;
-  transition: background-color 0.2s ease;
-
-  &:hover {
-    background-color: #d8cdc6;
-  }
-
-  @media (max-width: 768px) {
-    padding: 1rem;
-  }
-`;
-
-const IconWrapper = styled.div`
-  margin-right: 1rem;
-  font-size: 3rem;
-  color: #a30027;
-
-  @media (max-width: 768px) {
-    font-size: 2rem;
-  }
-`;
-
-const TextWrapper = styled.div`
-  flex: 1;
-`;
-
-const Title = styled.h3`
-  font-size: 1.2rem;
-  margin: 0;
-  font-weight: bold;
-
-  @media (max-width: 768px) {
-    font-size: 1.05rem;
-  }
-`;
-
-const SubText = styled.p`
-  margin: 0.25rem 0 0;
-  font-size: 0.95rem;
-  color: #555;
-
-  @media (max-width: 768px) {
-    font-size: 0.85rem;
-  }
-`;
-
-const ArrowWrapper = styled.div`
-  margin-left: auto;
-  font-size: 1.5rem;
-  color: #a30027;
-
-  @media (max-width: 768px) {
-    font-size: 1.2rem;
-  }
-`;
 
 const VerticalButtonSection: React.FC = () => {
   return (
     <Container>
-      <CardButton href="/">
-        <IconWrapper>
-          <ProfessorIcon />
-        </IconWrapper>
-        <TextWrapper>
-          <Title>교수진 소개</Title>
-          <SubText>Meet our esteemed professors</SubText>
-        </TextWrapper>
-        <ArrowWrapper>
-          <ArrowIcon />
-        </ArrowWrapper>
-      </CardButton>
-
-      <CardButton href="/">
-        <IconWrapper>
-          <BookIcon />
-        </IconWrapper>
-        <TextWrapper>
-          <Title>교과과정 안내</Title>
-          <SubText>See our curriculum details</SubText>
-        </TextWrapper>
-        <ArrowWrapper>
-          <ArrowIcon />
-        </ArrowWrapper>
-      </CardButton>
+      {cardData.map((item, index) => (
+        <CardButton href={item.link} key={index}>
+          <IconWrapper>
+            <item.icon />
+          </IconWrapper>
+          <TextWrapper>
+            <Title>{item.title}</Title>
+            <SubText>{item.subText}</SubText>
+          </TextWrapper>
+          <ArrowWrapper>
+            <ArrowIcon />
+          </ArrowWrapper>
+        </CardButton>
+      ))}
     </Container>
   );
 };

--- a/frontend/src/pages/Main/components/VerticalButtonSection/VerticalButtonSectionStyle.ts
+++ b/frontend/src/pages/Main/components/VerticalButtonSection/VerticalButtonSectionStyle.ts
@@ -1,0 +1,72 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  flex: 0.6;
+`;
+
+export const CardButton = styled.a`
+  display: flex;
+  align-items: center;
+  background-color: #e9dfda;
+  border-radius: 8px;
+  padding: 1.5rem;
+  flex: 1;
+  text-decoration: none;
+  color: #333;
+  transition: background-color 0.2s ease;
+
+  &:hover {
+    background-color: #d8cdc6;
+  }
+
+  @media (max-width: 768px) {
+    padding: 1rem;
+  }
+`;
+
+export const IconWrapper = styled.div`
+  margin-right: 1rem;
+  font-size: 3rem;
+  color: #a30027;
+
+  @media (max-width: 768px) {
+    font-size: 2rem;
+  }
+`;
+
+export const TextWrapper = styled.div`
+  flex: 1;
+`;
+
+export const Title = styled.h3`
+  font-size: 1.2rem;
+  margin: 0;
+  font-weight: bold;
+
+  @media (max-width: 768px) {
+    font-size: 1.05rem;
+  }
+`;
+
+export const SubText = styled.p`
+  margin: 0.25rem 0 0;
+  font-size: 0.95rem;
+  color: #555;
+
+  @media (max-width: 768px) {
+    font-size: 0.85rem;
+  }
+`;
+
+export const ArrowWrapper = styled.div`
+  margin-left: auto;
+  font-size: 1.5rem;
+  color: #a30027;
+
+  @media (max-width: 768px) {
+    font-size: 1.2rem;
+  }
+`;

--- a/frontend/src/pages/Main/components/VerticalButtonSection/data.ts
+++ b/frontend/src/pages/Main/components/VerticalButtonSection/data.ts
@@ -1,0 +1,27 @@
+import { IconBaseProps } from 'react-icons';
+import { FaChalkboardTeacher, FaBook } from 'react-icons/fa';
+
+export interface CardItem {
+  icon: React.ComponentType<IconBaseProps>;
+  title: string;
+  subText: string;
+  link: string;
+}
+
+const ProfessorIcon = FaChalkboardTeacher as React.ComponentType<IconBaseProps>;
+const BookIcon = FaBook as React.ComponentType<IconBaseProps>;
+
+export const cardData: CardItem[] = [
+  {
+    icon: ProfessorIcon,
+    title: '교수진 소개',
+    subText: 'Meet our esteemed professors',
+    link: '/',
+  },
+  {
+    icon: BookIcon,
+    title: '교과과정 안내',
+    subText: 'See our curriculum details',
+    link: '/',
+  },
+];

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -21,7 +21,7 @@ export const theme: DefaultTheme = {
   layout: {
     types: {
       default: {
-        width: '85vw',
+        width: '100vw',
         maxWidth: '1500px',
         padding: '40px 20px',
       },


### PR DESCRIPTION
- [ ] 💯 테스트는 잘 통과했나요?
- [X] 🏗️ 빌드는 성공했나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?

## 작업 내용
- 메인 Banner 하단 버튼 리스트 컴포넌트 구현
- 메인페이지 공지사항 스타일 일부 변경
- 공지사항 우측 버튼 리스트 구현

## 스크린샷
- 변경된 메인 페이지 스크린샷
<img width="1507" alt="스크린샷 2025-03-01 오전 1 34 43" src="https://github.com/user-attachments/assets/30f092f4-5810-4628-b63b-b75bdffeb4bd" />
<img width="1512" alt="스크린샷 2025-03-01 오전 1 34 51" src="https://github.com/user-attachments/assets/8c21e5f2-1a01-4599-8915-7a9fcd8c539b" />
<img width="1512" alt="스크린샷 2025-03-01 오전 1 35 00" src="https://github.com/user-attachments/assets/371b85ae-2e10-42ca-a4f4-c8b66523ab0d" />

## 주의사항
- 더미 데이터들로 API 연결 필요
- react icons 라이브러리 설치, pull 받을시 npm install 필요


Closes #{이슈 번호}