### PR TITLE
[FE] [FEAT] 메인페이지 세미나 버튼 페이지 이동 구현

### DIFF
--- a/frontend/src/pages/Main/components/ButtonListSection/ButtonListSection.tsx
+++ b/frontend/src/pages/Main/components/ButtonListSection/ButtonListSection.tsx
@@ -1,4 +1,3 @@
-// ButtonListSection.tsx
 import React from 'react';
 import {
   ButtonListContainer,
@@ -24,13 +23,24 @@ const ButtonListSection: React.FC = () => {
     sortDirection: 'DESC',
   });
 
+  const handleSeminarClick = () => {
+    if (seminarData && seminarData.data && seminarData.data.length > 0) {
+      window.location.href = `/news/seminar/${seminarData.data[0].id}`;
+    }
+  };
+
   return (
     <ButtonListContainer>
       <ButtonListList>
         {buttonItems.map((item, index) => {
           if (item.isSeminar) {
             return (
-              <ButtonListItem key={index} isSeminar>
+              <ButtonListItem
+                key={index}
+                isSeminar
+                onClick={handleSeminarClick}
+                style={{ cursor: 'pointer' }}
+              >
                 <SeminarInfoWrapper>
                   <SeminarInfoTop>{'예정된 세미나'}</SeminarInfoTop>
                   {isSeminarLoading ? (
@@ -46,8 +56,7 @@ const ButtonListSection: React.FC = () => {
                       </SeminarInfoTitle>
                       <SeminarInfoSubtitle>
                         {'시간 : '}
-                        {seminarData.data[0].startTime}
-                        {' ~ '}
+                        {seminarData.data[0].startTime} ~{' '}
                         {seminarData.data[0].endTime}
                       </SeminarInfoSubtitle>
                       {seminarData.data[0].writer && (
@@ -78,13 +87,10 @@ const ButtonListSection: React.FC = () => {
             );
           }
 
-          // 일반 버튼 아이템인 경우
           return (
             <ButtonListItem key={index} isSeminar={item.isSeminar}>
               <a href={item.link} rel="noopener noreferrer">
-                {React.createElement(item.icon, {
-                  size: 0,
-                })}
+                {React.createElement(item.icon, { size: 0 })}
                 <span>{item.title}</span>
               </a>
             </ButtonListItem>

--- a/frontend/src/pages/Main/components/ButtonListSection/ButtonListSectionStyle.ts
+++ b/frontend/src/pages/Main/components/ButtonListSection/ButtonListSectionStyle.ts
@@ -42,6 +42,10 @@ export const ButtonListItem = styled.li<ButtonListItemProps>`
       position: relative;
       flex: 1.5;
       display: block;
+
+      &:hover {
+        background-color: #ae283f;
+      }
     `}
 
   a {

--- a/frontend/src/pages/Main/components/ButtonListSection/data.ts
+++ b/frontend/src/pages/Main/components/ButtonListSection/data.ts
@@ -41,7 +41,7 @@ export const buttonItems: ButtonItem[] = [
   {
     title: '학생회 안내',
     icon: StudentIcon,
-    link: 'https://ibb.sejong.ac.kr/about/studentcouncil',
+    link: '/about/studentcouncil',
     isSeminar: false,
   },
   {

--- a/frontend/src/pages/Main/components/VerticalButtonSection/data.ts
+++ b/frontend/src/pages/Main/components/VerticalButtonSection/data.ts
@@ -16,12 +16,12 @@ export const cardData: CardItem[] = [
     icon: ProfessorIcon,
     title: '교수진 소개',
     subText: 'Meet our esteemed professors',
-    link: 'https://ibb.sejong.ac.kr/about/faculty',
+    link: '/about/faculty',
   },
   {
     icon: BookIcon,
     title: '교과과정 안내',
     subText: 'See our curriculum details',
-    link: 'https://ibb.sejong.ac.kr/graduate/curriculum',
+    link: '/undergraduate/curriculum',
   },
 ];


### PR DESCRIPTION
- [ ] 💯 테스트는 잘 통과했나요?
- [X] 🏗️ 빌드는 성공했나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?

## 작업 내용
- 메인페이지 링크 정정
- 세미나 클릭시 페이지 이동 구현

## 스크린샷
- 세미나 버튼 효과 및 페이지 이동 구현
<img width="1512" alt="스크린샷 2025-03-04 오전 9 44 26" src="https://github.com/user-attachments/assets/5ed95404-3f4a-4181-b6c6-a2559603e3d3" />

## 주의사항



Closes #{이슈 번호}