### PR TITLE
[FE] [FEAT] 일부 텍스트 및 디자인 수정

### DIFF
--- a/frontend/src/components/Footer/Footer.tsx
+++ b/frontend/src/components/Footer/Footer.tsx
@@ -71,8 +71,8 @@ function Footer() {
         titleLink: '/about',
         contents: [
           { type: 'link', name: '학과소개', link: '/about' },
-          { type: 'link', name: '조직도', link: '/about/organization' },
           { type: 'link', name: '교수소개', link: '/about/faculty' },
+          { type: 'link', name: '조직도', link: '/about/organization' },
           { type: 'link', name: '학생회', link: '/about/studentcouncil' },
         ],
       },

--- a/frontend/src/components/Footer/Footer.tsx
+++ b/frontend/src/components/Footer/Footer.tsx
@@ -80,7 +80,6 @@ function Footer() {
         title: '대학',
         titleLink: '/undergraduate/curriculum',
         contents: [
-          { type: 'link', name: '학사안내', link: '/college/guide' },
           {
             type: 'link',
             name: '학부교과과정',
@@ -176,7 +175,7 @@ function Footer() {
         </S.FooterContainer>
         <S.Copyright>
           <span>
-            Copyright©2025 . 세종대학교 바이오융합공학전공 All rights reserved
+            Copyright©2025. 세종대학교 바이오융합공학전공 All rights reserved
           </span>
         </S.Copyright>
       </S.FooterInner>

--- a/frontend/src/pages/Main/components/ButtonListSection/ButtonListSection.tsx
+++ b/frontend/src/pages/Main/components/ButtonListSection/ButtonListSection.tsx
@@ -54,27 +54,27 @@ const ButtonListSection: React.FC = () => {
                       <SeminarInfoTitle>
                         {seminarData.data[0].name}
                       </SeminarInfoTitle>
-                      <SeminarInfoSubtitle>
-                        {'시간 : '}
-                        {seminarData.data[0].startTime} ~{' '}
-                        {seminarData.data[0].endTime}
-                      </SeminarInfoSubtitle>
                       {seminarData.data[0].writer && (
                         <SeminarInfoSubtitle>
-                          {'예약자 : '}
+                          {'연사 : '}
                           {seminarData.data[0].writer}
                         </SeminarInfoSubtitle>
                       )}
+                      <SeminarInfoSubtitle>
+                        {'소속 : '}
+                        {seminarData.data[0].company}
+                      </SeminarInfoSubtitle>
+                      <SeminarInfoSubtitle>
+                        {'일시 : '}
+                        {seminarData.data[0].startTime} ~{' '}
+                        {seminarData.data[0].endTime}
+                      </SeminarInfoSubtitle>
                       {seminarData.data[0].place && (
                         <SeminarInfoSubtitle>
                           {'장소 : '}
                           {seminarData.data[0].place}
                         </SeminarInfoSubtitle>
                       )}
-                      <SeminarInfoSubtitle>
-                        {'부서 : '}
-                        {seminarData.data[0].company}
-                      </SeminarInfoSubtitle>
                     </>
                   ) : (
                     <div>세미나 정보가 없습니다.</div>

--- a/frontend/src/pages/Main/components/ButtonListSection/ButtonListSectionStyle.ts
+++ b/frontend/src/pages/Main/components/ButtonListSection/ButtonListSectionStyle.ts
@@ -122,7 +122,7 @@ export const SeminarInfoTop = styled.h3`
 `;
 
 export const SeminarInfoTitle = styled.h3`
-  font-size: 1.5rem;
+  font-size: 1.4rem;
   margin: 0 0 1rem 0;
 `;
 

--- a/frontend/src/pages/Seminar/SeminarCreate.tsx
+++ b/frontend/src/pages/Seminar/SeminarCreate.tsx
@@ -149,13 +149,13 @@ const SeminarCreate = () => {
           </FormGroup>
 
           <FormGroup>
-            <Label>발표자</Label>
+            <Label>연사</Label>
             <Input
               type="text"
               name="speaker"
               value={formData.speaker}
               onChange={handleChange}
-              placeholder="발표자 이름을 입력하세요"
+              placeholder="연사 이름을 입력하세요"
             />
           </FormGroup>
 

--- a/frontend/src/pages/Seminar/SeminarDetail.tsx
+++ b/frontend/src/pages/Seminar/SeminarDetail.tsx
@@ -171,7 +171,7 @@ const SeminarDetail: React.FC = () => {
             <InfoSection>
               <InfoGrid>
                 <InfoRow>
-                  <InfoLabel>발표자</InfoLabel>
+                  <InfoLabel>연사</InfoLabel>
                   <InfoValue>{seminar.speaker}</InfoValue>
                 </InfoRow>
                 <InfoRow>

--- a/frontend/src/pages/Seminar/SeminarEdit.tsx
+++ b/frontend/src/pages/Seminar/SeminarEdit.tsx
@@ -176,13 +176,13 @@ const SeminarEdit = () => {
           </FormGroup>
 
           <FormGroup>
-            <Label>발표자</Label>
+            <Label>연사</Label>
             <Input
               type="text"
               name="speaker"
               value={formData.speaker}
               onChange={handleChange}
-              placeholder="발표자 이름을 입력하세요"
+              placeholder="연사 이름을 입력하세요"
             />
           </FormGroup>
 

--- a/frontend/src/pages/Seminar/SeminarList.tsx
+++ b/frontend/src/pages/Seminar/SeminarList.tsx
@@ -179,7 +179,7 @@ const SeminarList = () => {
   const columns = [
     { key: 'id', label: '번호', width: '5%' },
     { key: 'name', label: '세미나명', width: '25%' },
-    { key: 'speaker', label: '발표자', width: '10%' },
+    { key: 'speaker', label: '연사', width: '10%' },
     { key: 'company', label: '소속', width: '15%' },
     { key: 'place', label: '장소', width: '10%' },
     {


### PR DESCRIPTION
- [ ] 💯 테스트는 잘 통과했나요?
- [X] 🏗️ 빌드는 성공했나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?

## 작업 내용
- 발표자 -> 연사로 표현 정정
- 메인페이지 세미나 부분 텍스트 순서 조정
- Footer 삭제 및 순서 정정

## 스크린샷
* 메인페이지 세미나 수정
<img width="1512" alt="스크린샷 2025-03-07 오전 6 37 22" src="https://github.com/user-attachments/assets/3a49c954-81e8-47fd-96e8-9994b62793c0" />

* Footer 수정
<img width="1512" alt="스크린샷 2025-03-07 오전 6 37 30" src="https://github.com/user-attachments/assets/1437c8c1-f00f-41ca-9c26-b8c474065a57" />

* 발표자 -> 연사로 텍스트 수정
<img width="1512" alt="스크린샷 2025-03-07 오전 6 37 50" src="https://github.com/user-attachments/assets/7b361a44-a620-482d-82f8-80243fa1dda2" />



## 주의사항
- 모니터 크기에 따른 메인페이지 깨짐 현상은 정상으로 보여 아직 확인 못함

Closes #440